### PR TITLE
Add basic XML tag generation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,19 @@
 Copyright 2017 "Shopify inc."
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
-
-3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md LICENSE

--- a/Makefile
+++ b/Makefile
@@ -24,5 +24,6 @@ autopep8:
 lint:
 		@echo 'Linting...'
 		@pylint --rcfile=pylintrc pyoozie tests
+		@flake8
 
 autolint: autopep8 lint

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,8 @@
 pytest>=2.7
 pytest-cov
 pytest-randomly
+pytest-mock
 pylint
+xmltodict
 autopep8
+flake8

--- a/pylintrc
+++ b/pylintrc
@@ -35,8 +35,18 @@ load-plugins=
 # it should appear only once).
 
 # CHANGED:
+# too-few-public-methods
+# too-many-instance-attributes
+# too-many-arguments
+# protected-access; _xml() calls
+# invalid-name; some 2-letter variables are OK
+# redefined-outer-name; doesn't play well with pytest fixtures
+# fixme; we're in-development, so we need some of these
 # C0111: Missing docstring
-disable=C0111
+# D101 Missing docstring in public class
+# D102 Missing docstring in public method
+# D105 Missing docstring in magic method
+disable=C0111,D101,D102,D105,too-few-public-methods,too-many-instance-attributes,too-many-arguments,protected-access,invalid-name,redefined-outer-name,fixme
 
 
 [REPORTS]

--- a/pylintrc
+++ b/pylintrc
@@ -46,7 +46,8 @@ load-plugins=
 # D101 Missing docstring in public class
 # D102 Missing docstring in public method
 # D105 Missing docstring in magic method
-disable=C0111,D101,D102,D105,too-few-public-methods,too-many-instance-attributes,too-many-arguments,protected-access,invalid-name,redefined-outer-name,fixme
+disable=C0111,D101,D102,D105,too-few-public-methods,too-many-instance-attributes,too-many-arguments,
+ protected-access,invalid-name,redefined-outer-name,fixme
 
 
 [REPORTS]

--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -2,9 +2,9 @@
 # Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 from pyoozie.coordinator import Coordinator, ExecutionOrder
-from pyoozie.tags import validate, Parameters, Configuration, Credentials, Shell, SubWorkflow, GlobalConfiguration, \
+from pyoozie.tags import Parameters, Configuration, Credentials, Shell, SubWorkflow, GlobalConfiguration, \
     Email, IdentifierTooLongError
-from pyoozie.builder import workflow, coordinator, _coordinator_submission_xml, _workflow_submission_xml
+from pyoozie.builder import workflow, coordinator
 
 __version__ = '0.0.0'
 
@@ -13,9 +13,9 @@ __all__ = (
     'Coordinator', 'ExecutionOrder', 'Configuration', 'Parameters',
 
     # tags
-    'validate', 'Parameters', 'Configuration', 'Credentials', 'Shell', 'SubWorkflow', 'GlobalConfiguration', \
+    'Parameters', 'Configuration', 'Credentials', 'Shell', 'SubWorkflow', 'GlobalConfiguration', \
     'Email', 'IdentifierTooLongError',
 
     # builder
-    'workflow', 'coordinator', '_coordinator_submission_xml', '_workflow_submission_xml',
+    'workflow', 'coordinator',
 )

--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -4,7 +4,7 @@
 from pyoozie.coordinator import Coordinator, ExecutionOrder
 from pyoozie.tags import Parameters, Configuration, Credentials, Shell, SubWorkflow, GlobalConfiguration, \
     Email, IdentifierTooLongError
-from pyoozie.builder import workflow, coordinator
+from pyoozie.builder import WorkflowBuilder, CoordinatorBuilder
 
 __version__ = '0.0.0'
 
@@ -17,5 +17,5 @@ __all__ = (
     'Email', 'IdentifierTooLongError',
 
     # builder
-    'workflow', 'coordinator',
+    'WorkflowBuilder', 'CoordinatorBuilder',
 )

--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 
 from pyoozie.coordinator import Coordinator, ExecutionOrder
 from pyoozie.tags import Parameters, Configuration, Credentials, Shell, SubWorkflow, GlobalConfiguration, Email

--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -1,4 +1,21 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
+from pyoozie.coordinator import Coordinator, ExecutionOrder
+from pyoozie.tags import validate, Parameters, Configuration, Credentials, Shell, SubWorkflow, GlobalConfiguration, \
+    Email, IdentifierTooLongError
+from pyoozie.builder import workflow, coordinator, _coordinator_submission_xml, _workflow_submission_xml
+
 __version__ = '0.0.0'
+
+__all__ = (
+    # coordinator
+    'Coordinator', 'ExecutionOrder', 'Configuration', 'Parameters',
+
+    # tags
+    'validate', 'Parameters', 'Configuration', 'Credentials', 'Shell', 'SubWorkflow', 'GlobalConfiguration', \
+    'Email', 'IdentifierTooLongError',
+
+    # builder
+    'workflow', 'coordinator', '_coordinator_submission_xml', '_workflow_submission_xml',
+)

--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -2,8 +2,7 @@
 # Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 from pyoozie.coordinator import Coordinator, ExecutionOrder
-from pyoozie.tags import Parameters, Configuration, Credentials, Shell, SubWorkflow, GlobalConfiguration, \
-    Email, IdentifierTooLongError
+from pyoozie.tags import Parameters, Configuration, Credentials, Shell, SubWorkflow, GlobalConfiguration, Email
 from pyoozie.builder import WorkflowBuilder, CoordinatorBuilder
 
 __version__ = '0.0.0'
@@ -13,8 +12,7 @@ __all__ = (
     'Coordinator', 'ExecutionOrder', 'Configuration', 'Parameters',
 
     # tags
-    'Parameters', 'Configuration', 'Credentials', 'Shell', 'SubWorkflow', 'GlobalConfiguration', \
-    'Email', 'IdentifierTooLongError',
+    'Parameters', 'Configuration', 'Credentials', 'Shell', 'SubWorkflow', 'GlobalConfiguration', 'Email',
 
     # builder
     'WorkflowBuilder', 'CoordinatorBuilder',

--- a/pyoozie/builder.py
+++ b/pyoozie/builder.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals
 
 from pyoozie.coordinator import Coordinator

--- a/pyoozie/builder.py
+++ b/pyoozie/builder.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2017 "Shopify inc." All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+from __future__ import unicode_literals
+
+from pyoozie.coordinator import Coordinator
+from pyoozie.tags import Configuration, Parameters
+
+
+def _workflow_submission_xml(hadoop_user, hdfs_path, configuration=None, indent=False):
+    """Generate a Workflow XML submission message to POST to Oozie."""
+    submission = Configuration(configuration)
+    submission.update({
+        'user.name': hadoop_user,
+        'oozie.wf.application.path': hdfs_path
+    })
+    return submission.xml(indent)
+
+
+def _coordinator_submission_xml(hadoop_user, hdfs_path, configuration=None, indent=False):
+    """Generate a Coordinator XML submission message to POST to Oozie."""
+    submission = Configuration(configuration)
+    submission.update({
+        'user.name': hadoop_user,
+        'oozie.coord.application.path': hdfs_path,
+    })
+    return submission.xml(indent)
+
+
+class workflow(object):
+
+    def __init__(self, name):
+        # Initially, let's just use a static template and only one action payload and one action on error
+        self._name = name
+        self._action_name = None
+        self._action_payload = None
+        self._action_error = None
+        self._kill_message = None
+
+    def add_action(self, name, action, action_on_error, kill_on_error='${wf:lastErrorNode()} - ${wf:id()}'):
+        # Today you can't rename your action and you can only have one, but in the future you can add multiple
+        # named actions
+        if self._action_name is None and self._action_payload is None and self._action_error is None and \
+           self._kill_message is None:
+            self._action_name = name
+            self._action_payload = action
+            self._action_error = action_on_error
+            self._kill_message = kill_on_error
+        else:
+            raise NotImplementedError("Can only add one action in this version")
+        return self
+
+    def build(self, indent=False):
+        def remove_header(xml):
+            return xml.replace("<?xml version='1.0' encoding='UTF-8'?>", '')
+        return '''
+<?xml version="1.0" encoding="UTF-8"?>
+<workflow-app xmlns="uri:oozie:workflow:0.5"
+              name="{name}">
+    <start to="action-{action_name}" />
+    <action name="action-{action_name}">
+        {action_payload_xml}
+        <ok to="end" />
+        <error to="action-error" />
+    </action>
+    <action name="action-error">
+        {action_error_xml}
+        <ok to="kill" />
+        <error to="kill" />
+    </action>
+    <kill name="kill">
+        <message>{kill_message}</message>
+    </kill>
+    <end name="end" />
+</workflow-app>
+'''.format(action_payload_xml=remove_header(self._action_payload.xml(indent=indent)),
+           action_error_xml=remove_header(self._action_error.xml(indent=indent)),
+           kill_message=self._kill_message,
+           action_name=self._action_name,
+           name=self._name).strip()
+
+    def submit(self, oozie_url, hdfs_path, hadoop_user, hdfs_callback, timeout_in_seconds=None,
+               verbose=False, start=False, indent=False):
+        xml = self.build(indent=indent)
+        hdfs_callback(hdfs_path, xml)
+        # TODO create Oozie API and submit
+        from mock import Mock
+        OozieAPI = Mock()
+        api = OozieAPI(url=oozie_url, user=hadoop_user, timeout=timeout_in_seconds, verbose=verbose)
+        api.jobs_submit_workflow(hdfs_path=hdfs_path, start=start)
+        raise NotImplementedError()
+
+
+class coordinator(object):
+
+    def __init__(self, name, workflow, frequency_in_minutes, start, end=None, timezone=None,
+                 workflow_configuration=None, timeout_in_minutes=None, concurrency=None, execution_order=None,
+                 throttle=None, parameters=None):
+        workflow_configuration = Configuration(workflow_configuration) if workflow_configuration else None
+        self._coordinator = Coordinator(
+            name=name,
+            workflow_app_path=None,  # Defer this until the build
+            frequency=frequency_in_minutes,
+            start=start,
+            end=end,
+            timezone=timezone,
+            workflow_configuration=workflow_configuration,
+            timeout=timeout_in_minutes,
+            concurrency=concurrency,
+            execution_order=execution_order,
+            throttle=throttle,
+            parameters=Parameters(parameters) if parameters else None
+        )
+        self._workflow = workflow
+
+    def build(self, workflow_hdfs_path, indent=False):
+        self._coordinator.workflow_app_path = workflow_hdfs_path
+        return self._coordinator.xml(indent)
+
+    def submit(self, oozie_url, workflow_hdfs_path, coord_hdfs_path, hadoop_user, hdfs_callback,
+               timeout_in_seconds=None, verbose=False, indent=False):
+        self._workflow.submit(
+            oozie_url=oozie_url,
+            hdfs_path=workflow_hdfs_path,
+            hadoop_user=hadoop_user,
+            hdfs_callback=hdfs_callback,
+            start=False,
+            indent=False)
+        xml = self.build(workflow_hdfs_path, indent=indent)
+        hdfs_callback(coord_hdfs_path, xml)
+        # TODO create Oozie API and submit
+        from mock import Mock
+        OozieAPI = Mock()
+        api = OozieAPI(url=oozie_url, user=hadoop_user, timeout=timeout_in_seconds, verbose=verbose)
+        api.job_submit_coordinator(hdfs_path=coord_hdfs_path)
+        raise NotImplementedError()

--- a/pyoozie/coordinator.py
+++ b/pyoozie/coordinator.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from datetime import timedelta
 from enum import Enum
 
-from pyoozie.tags import Xml, Parameters, validate
+from pyoozie.tags import  _validate, Xml, Parameters
 
 
 class ExecutionOrder(Enum):
@@ -52,7 +52,7 @@ class Coordinator(Xml):
         assert frequency >= 5, "Frequency (%d min) must be greater than or equal to 5 min" % frequency
 
         # Coordinator
-        self.name = validate(name)
+        self.name = _validate(name)
         self.frequency = frequency
         self.start = start
         self.end = end

--- a/pyoozie/coordinator.py
+++ b/pyoozie/coordinator.py
@@ -71,7 +71,7 @@ class Coordinator(Xml):
         self.parameters = Parameters(parameters)
 
     def _xml(self, doc, tag, text):
-        with tag(self.xml_tag, xmlns="uri:oozie:coordinator:0.5", name=self.name, frequency=unicode(self.frequency),
+        with tag(self.xml_tag, xmlns="uri:oozie:coordinator:0.5", name=self.name, frequency=str(self.frequency),
                  start=format_datetime(self.start), end=format_datetime(self.end), timezone=self.timezone):
 
             if self.parameters:

--- a/pyoozie/coordinator.py
+++ b/pyoozie/coordinator.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2017 "Shopify inc." All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+from __future__ import unicode_literals
+
+from datetime import timedelta
+from enum import Enum
+
+from pyoozie.tags import Xml, Parameters, validate
+
+
+class ExecutionOrder(Enum):
+    """Execution order used for coordinator jobs."""
+
+    FIFO = 'FIFO'
+
+    LIFO = 'LIFO'
+
+    LAST_ONLY = 'LAST_ONLY'
+    # "When LAST_ONLY is set, an action that is WAITING or READY will be SKIPPED when the current time is past the
+    # next action's nominal time.  For example, suppose action 1 and 2 are both WAITING , the current time is
+    # 5:00pm, and action 2's nominal time is 5:10pm. In 10 minutes from now, at 5:10pm, action 1 will become
+    # SKIPPED, assuming it doesn't transition to SUBMITTED (or a terminal state) before then. Another way of
+    # thinking about this is to view it as similar to setting the timeout equal to the frequency, except that the
+    # SKIPPED status doesn't cause the coordinator job to eventually become DONEWITHERROR and can actually become
+    # SUCCEEDED (i.e. it's a "good" version of TIMEDOUT ). LAST_ONLY is useful if you want a recurring job, but do
+    # not actually care about the individual instances and just always want the latest action."
+
+    NONE = 'NONE'
+    # "Similar to LAST_ONLY except all older materializations are skipped. When NONE is set, an action that is
+    # WAITING or READY will be SKIPPED when the current time is more than a certain configured number of minutes
+    # (tolerance) past the action's nominal time."
+
+    def __str__(self):
+        return self.value
+
+
+def format_datetime(value):
+    return value.strftime('%Y-%m-%dT%H:%MZ')
+
+
+class Coordinator(Xml):
+
+    def __init__(self, name, workflow_app_path, frequency, start, end=None, timezone=None,
+                 workflow_configuration=None, timeout=None, concurrency=None, execution_order=None, throttle=None,
+                 parameters=None):
+        super(Coordinator, self).__init__('coordinator-app')
+        # Compose and validate dates/frequencies
+        if end is None:
+            end = start + timedelta(days=100 * 365.24)
+        assert end > start, "End time (%s) must be greater than the start time (%s)" % \
+            (format_datetime(end), format_datetime(start))
+        assert frequency >= 5, "Frequency (%d min) must be greater than or equal to 5 min" % frequency
+
+        # Coordinator
+        self.name = validate(name)
+        self.frequency = frequency
+        self.start = start
+        self.end = end
+        self.timezone = timezone if timezone else 'UTC'
+
+        # Workflow action
+        self.workflow_app_path = workflow_app_path
+        self.workflow_configuration = workflow_configuration
+
+        # Controls
+        self.timeout = timeout
+        self.concurrency = concurrency
+        self.execution_order = execution_order
+        self.throttle = throttle
+
+        self.parameters = Parameters(parameters)
+
+    def _xml(self, doc, tag, text):
+        with tag(self.xml_tag, xmlns="uri:oozie:coordinator:0.5", name=self.name, frequency=unicode(self.frequency),
+                 start=format_datetime(self.start), end=format_datetime(self.end), timezone=self.timezone):
+
+            if self.parameters:
+                self.parameters._xml(doc, tag, text)
+
+            if self.timeout or self.concurrency or self.execution_order or self.throttle:
+                with tag('controls'):
+                    if self.timeout:
+                        with tag('timeout'):
+                            text(str(self.timeout))
+                    if self.concurrency:
+                        with tag('concurrency'):
+                            text(str(self.concurrency))
+                    if self.execution_order:
+                        with tag('execution'):
+                            text(str(self.execution_order))
+                    if self.throttle:
+                        with tag('throttle'):
+                            text(str(self.throttle))
+
+            with tag('action'):
+                with tag('workflow'):
+                    with tag('app-path'):
+                        text(self.workflow_app_path)
+                    if self.workflow_configuration:
+                        self.workflow_configuration._xml(doc, tag, text)
+
+        return doc

--- a/pyoozie/coordinator.py
+++ b/pyoozie/coordinator.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from datetime import timedelta
 from enum import Enum
 
-from pyoozie.tags import  _validate, Xml, Parameters
+from pyoozie.tags import _validate, Xml, Parameters
 
 
 class ExecutionOrder(Enum):

--- a/pyoozie/coordinator.py
+++ b/pyoozie/coordinator.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals
 
 from datetime import timedelta

--- a/pyoozie/coordinator.py
+++ b/pyoozie/coordinator.py
@@ -8,6 +8,9 @@ from enum import Enum
 from pyoozie.tags import _validate, Xml, Parameters, Configuration
 
 
+ONE_HUNDRED_YEARS = 100 * 365.24
+
+
 class ExecutionOrder(Enum):
     """Execution order used for coordinator jobs."""
 
@@ -32,10 +35,11 @@ class Coordinator(Xml):
         super(Coordinator, self).__init__('coordinator-app')
         # Compose and validate dates/frequencies
         if end is None:
-            end = start + timedelta(days=100 * 365.24)
-        assert end > start, "End time (%s) must be greater than the start time (%s)" % \
-            (format_datetime(end), format_datetime(start))
-        assert frequency >= 5, "Frequency (%d min) must be greater than or equal to 5 min" % frequency
+            end = start + timedelta(days=ONE_HUNDRED_YEARS)
+        assert end > start, "End time ({end}) must be greater than the start time ({start})".format(
+            end=format_datetime(end), start=format_datetime(start))
+        assert frequency >= 5, "Frequency ({frequency} min) must be greater than or equal to 5 min".format(
+            frequency=frequency)
 
         # Coordinator
         self.name = _validate(name)

--- a/pyoozie/coordinator.py
+++ b/pyoozie/coordinator.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from datetime import timedelta
 from enum import Enum
 
-from pyoozie.tags import _validate, Xml, Parameters, Configuration
+from pyoozie.tags import _validate, XMLSerializable, Parameters, Configuration
 
 
 ONE_HUNDRED_YEARS = 100 * 365.24
@@ -27,7 +27,7 @@ def format_datetime(value):
     return value.strftime('%Y-%m-%dT%H:%MZ')
 
 
-class Coordinator(Xml):
+class Coordinator(XMLSerializable):
 
     def __init__(self, name, workflow_app_path, frequency, start, end=None, timezone=None,
                  workflow_configuration=None, timeout=None, concurrency=None, execution_order=None, throttle=None,

--- a/pyoozie/coordinator.py
+++ b/pyoozie/coordinator.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals
 from datetime import timedelta
 from enum import Enum
 
-from pyoozie.tags import _validate, Xml, Parameters
+from pyoozie.tags import _validate, Xml, Parameters, Configuration
 
 
 class ExecutionOrder(Enum):
@@ -46,7 +46,7 @@ class Coordinator(Xml):
 
         # Workflow action
         self.workflow_app_path = workflow_app_path
-        self.workflow_configuration = workflow_configuration
+        self.workflow_configuration = Configuration(workflow_configuration)
 
         # Controls
         self.timeout = timeout

--- a/pyoozie/coordinator.py
+++ b/pyoozie/coordinator.py
@@ -12,23 +12,9 @@ class ExecutionOrder(Enum):
     """Execution order used for coordinator jobs."""
 
     FIFO = 'FIFO'
-
     LIFO = 'LIFO'
-
     LAST_ONLY = 'LAST_ONLY'
-    # "When LAST_ONLY is set, an action that is WAITING or READY will be SKIPPED when the current time is past the
-    # next action's nominal time.  For example, suppose action 1 and 2 are both WAITING , the current time is
-    # 5:00pm, and action 2's nominal time is 5:10pm. In 10 minutes from now, at 5:10pm, action 1 will become
-    # SKIPPED, assuming it doesn't transition to SUBMITTED (or a terminal state) before then. Another way of
-    # thinking about this is to view it as similar to setting the timeout equal to the frequency, except that the
-    # SKIPPED status doesn't cause the coordinator job to eventually become DONEWITHERROR and can actually become
-    # SUCCEEDED (i.e. it's a "good" version of TIMEDOUT ). LAST_ONLY is useful if you want a recurring job, but do
-    # not actually care about the individual instances and just always want the latest action."
-
     NONE = 'NONE'
-    # "Similar to LAST_ONLY except all older materializations are skipped. When NONE is set, an action that is
-    # WAITING or READY will be SKIPPED when the current time is more than a certain configured number of minutes
-    # (tolerance) past the action's nominal time."
 
     def __str__(self):
         return self.value

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -1,0 +1,316 @@
+# Copyright (c) 2017 "Shopify inc." All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+from __future__ import unicode_literals
+from abc import ABCMeta, abstractmethod
+import re
+import yattag
+
+
+MAX_IDENTIFIER_LENGTH = 39
+REGEX_IDENTIFIER = r'^[a-zA-Z_][\-_a-zA-Z0-9]{0,38}$'
+COMPILED_REGEX_IDENTIFIER = re.compile(REGEX_IDENTIFIER)
+
+
+class IdentifierTooLongError(AssertionError):
+
+    def __init__(self, identifier):
+        AssertionError.__init__(self, "Identifier must be less than {max_length} chars long, '{identifier}' is "
+                                "{length}".format(max_length=MAX_IDENTIFIER_LENGTH,
+                                                  identifier=identifier,
+                                                  length=len(identifier)))
+        self.length = len(identifier)
+
+
+def validate(identifier):
+
+    if len(identifier) > MAX_IDENTIFIER_LENGTH:
+        raise IdentifierTooLongError(identifier)
+
+    assert COMPILED_REGEX_IDENTIFIER.match(identifier), \
+        "Identifier must match {regex}, '{identifier}' does not".format(
+            regex=REGEX_IDENTIFIER,
+            identifier=identifier)
+
+    return identifier
+
+
+class Xml(object):
+    """An abstract object that can be serialized to XML."""
+
+    __metaclass__ = ABCMeta
+
+    def __init__(self, xml_tag):
+        self.xml_tag = xml_tag
+
+    def xml(self, indent=False):
+        doc, tag, text = yattag.Doc().tagtext()
+        doc.asis("<?xml version='1.0' encoding='UTF-8'?>")
+        xml = self._xml(doc, tag, text).getvalue()
+        if indent:
+            return yattag.indent(xml, indentation=' ' * 4, newline='\r\n')
+        else:
+            return xml
+
+    @abstractmethod
+    def _xml(self, doc, tag, text):
+        raise NotImplementedError
+
+    def __str__(self):
+        return self.xml_tag
+
+
+class _PropertyList(Xml, dict):
+    """
+    Object used to represent Oozie workflow/coordinator property-value sets.
+
+    Generates XML of the form:
+    ...
+    <xml_tag>
+      <property>
+        <name>[PROPERTY-NAME]</name>
+        <value>[PROPERTY-VALUE]</value>
+      </property>
+      ...
+    </xml_tag>
+    """
+
+    def __init__(self, xml_tag, attributes=None, values=None):
+        Xml.__init__(self, xml_tag)
+        if values:
+            dict.__init__(self, values)
+        else:
+            dict.__init__(self)
+        self.attributes = attributes if attributes else dict()
+
+    def _xml(self, doc, tag, text):
+        with tag(self.xml_tag, **self.attributes):
+            for name, value in sorted(self.items()):
+                with tag('property'):
+                    with tag('name'):
+                        doc.text(unicode(name))
+                    with tag('value'):
+                        doc.text(unicode(value) if value is not None else '')
+        return doc
+
+
+class Parameters(_PropertyList):
+    """Coordinator/workflow parameters.
+
+    Allows one to specify properties that can be reused in actions. "Properties that are a valid Java identifier,
+    [A-Za-z_][0-9A-Za-z_]* , are available as '${NAME}' variables within the workflow definition."
+
+    "Properties that are not valid Java Identifier, for example 'job.tracker', are available via the
+    String wf:conf(String name) function. Valid identifier properties are available via this function as well."
+    """
+
+    def __init__(self, values=None):
+        _PropertyList.__init__(self, 'parameters', values=values)
+
+
+class Configuration(_PropertyList):
+    """Coordinator job submission, workflow, workflow action configuration XML."""
+
+    def __init__(self, values=None):
+        _PropertyList.__init__(self, 'configuration', values=values)
+
+
+class Credentials(_PropertyList):
+    """HCatalog, Hive Metastore, HBase, or Hive Server 2 action credentials.
+
+    Generates XML of the form:
+    ```
+    ...
+    <credentials>
+      <credential name='my-hcat-creds' type='hcat'>
+         <property>
+            <name>hcat.metastore.uri</name>
+            <value>HCAT_URI</value>
+         </property>
+         ...
+      </credential>
+     </credentials>
+     <action name='pig' cred='my-hcat-creds'>
+       <pig>
+       ...
+    ```
+    """
+
+    def __init__(self, values, credential_name, credential_type):
+        _PropertyList.__init__(self, 'credentials',
+                               attributes={
+                                   'name': credential_name,
+                                   'type': credential_type,
+                               },
+                               values=values)
+        self.name = validate(credential_name)
+
+
+class Shell(Xml):
+    """Workflow shell action (v0.3)."""
+
+    def __init__(self, exec_command, job_tracker=None, name_node=None, prepares=None, job_xml_files=None,
+                 configuration=None, arguments=None, env_vars=None, files=None, archives=None, capture_output=False):
+        Xml.__init__(self, 'shell')
+        self.exec_command = exec_command
+        self.job_tracker = job_tracker
+        self.name_node = name_node
+        self.prepares = prepares if prepares else list()
+        self.job_xml_files = job_xml_files if job_xml_files else list()
+        self.configuration = Configuration(configuration)
+        self.arguments = arguments if arguments else list()
+        self.env_vars = env_vars if env_vars else dict()
+        self.files = files if files else list()
+        self.archives = archives if archives else list()
+        self.capture_output = capture_output
+
+    def _xml(self, doc, tag, text):
+        with tag(self.xml_tag, xmlns='uri:oozie:shell-action:0.3'):
+            if self.job_tracker:
+                with tag('job-tracker'):
+                    doc.text(self.job_tracker)
+
+            if self.name_node:
+                with tag('name-node'):
+                    doc.text(self.name_node)
+
+            if self.prepares:
+                raise NotImplementedError("Shell action's prepares has not yet been implemented")
+
+            for xml_file in self.job_xml_files:
+                with tag('job-xml'):
+                    doc.text(xml_file)
+
+            if self.configuration:
+                self.configuration._xml(doc, tag, text)
+
+            with tag('exec'):
+                doc.text(self.exec_command)
+
+            for argument in self.arguments:
+                with tag('argument'):
+                    doc.text(argument)
+
+            for env_var in self.env_vars.items():
+                with tag('env-var'):
+                    doc.text('%s=%s' % env_var)
+
+            for filename in self.files:
+                with tag('file'):
+                    doc.text(filename)
+
+            for archive in self.archives:
+                with tag('archive'):
+                    doc.text(archive)
+
+            if self.capture_output:
+                doc.stag('capture-output')
+
+        return doc
+
+
+class SubWorkflow(Xml):
+    """Run another workflow defined in another XML file on HDFS.
+
+    An Oozie sub-workflow is an "action [that] runs a child workflow job [...]. The parent workflow job will wait
+    until the child workflow job has completed."
+    """
+
+    def __init__(self, app_path, propagate_configuration=True, configuration=None):
+        Xml.__init__(self, 'sub-workflow')
+        self.app_path = app_path
+        self.propagate_configuration = propagate_configuration
+        self.configuration = Configuration(configuration)
+
+    def _xml(self, doc, tag, text):
+        with tag(self.xml_tag):
+            with tag('app-path'):
+                doc.text(self.app_path)
+            if self.propagate_configuration:
+                doc.stag('propagate-configuration')
+            if self.configuration:
+                self.configuration._xml(doc, tag, text)
+
+        return doc
+
+
+class GlobalConfiguration(Xml):
+    """Global configuration values for all actions in a workflow.
+
+    "Oozie allows a global section to reduce the redundant job-tracker and name-node declarations for each action.
+    [...] The global section may contain the job-xml, configuration, job-tracker, or name-node that the user would
+    like to set for every action.  If a user then redefines one of these in a specific action node, Oozie will
+    update [sic] use the specific declaration instead of the global one for that action."
+
+    "The job-xml element, if present, must refer to a Hadoop JobConf job.xml file bundled in the workflow
+    application."
+    """
+
+    def __init__(self, job_tracker='', name_node='', job_xml_files=None, configuration=None):
+        Xml.__init__(self, 'global')
+        self.job_tracker = job_tracker
+        self.name_node = name_node
+        self.job_xml_files = job_xml_files if job_xml_files else list()
+        self.configuration = Configuration(configuration)
+
+    def _xml(self, doc, tag, text):
+        with tag(self.xml_tag):
+            if self.job_tracker:
+                with tag('job-tracker'):
+                    doc.text(self.job_tracker)
+            if self.name_node:
+                with tag('name-node'):
+                    doc.text(self.name_node)
+            if self.job_xml_files:
+                for xml_file in self.job_xml_files:
+                    with tag('job-xml'):
+                        doc.text(xml_file)
+            if self.configuration:
+                self.configuration._xml(doc, tag, text)
+
+        return doc
+
+    def __nonzero__(self):
+        return any(bool(x) for x in [
+            self.job_tracker, self.name_node, self.job_xml_files,
+            self.configuration
+        ])
+
+
+class Email(Xml):
+    """Email action for use within a workflow."""
+
+    def __init__(self, to, subject, body, cc=None, bcc=None, content_type=None, attachments=None):
+        Xml.__init__(self, 'email')
+        self.to = to
+        self.subject = subject
+        self.body = body
+        self.cc = cc
+        self.bcc = bcc
+        self.content_type = content_type
+        self.attachments = attachments
+
+    def _xml(self, doc, tag, text):
+        def format_list(emails):
+            return ','.join(sorted(emails)) if hasattr(emails, '__iter__') else emails
+
+        with tag(self.xml_tag, xmlns='uri:oozie:email-action:0.2'):
+            with tag('to'):
+                doc.text(format_list(self.to))
+            with tag('subject'):
+                doc.text(self.subject)
+            with tag('body'):
+                doc.text(self.body)
+            if self.cc:
+                with tag('cc'):
+                    doc.text(format_list(self.cc))
+            if self.bcc:
+                with tag('bcc'):
+                    doc.text(format_list(self.bcc))
+            if self.content_type:
+                with tag('content_type'):
+                    doc.text(self.content_type)
+            if self.attachments:
+                with tag('attachment'):
+                    doc.text(format_list(self.attachments))
+
+        return doc

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -291,8 +291,10 @@ class Email(Xml):
 
     def _xml(self, doc, tag, text):
         def format_list(emails):
-            return ','.join(sorted(emails)) if hasattr(emails, '__iter__') and not \
-                isinstance(emails, str) else emails
+            if hasattr(emails, '__iter__') and not isinstance(emails, str):
+                return ','.join(sorted(emails))
+            else:
+                return emails
 
         with tag(self.xml_tag, xmlns='uri:oozie:email-action:0.2'):
             with tag('to'):

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals
 from abc import ABCMeta, abstractmethod
 import re

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -27,7 +27,7 @@ def _validate(identifier):
     return identifier
 
 
-class Xml(object):
+class XMLSerializable(object):
     """An abstract object that can be serialized to XML."""
 
     __metaclass__ = ABCMeta
@@ -52,7 +52,7 @@ class Xml(object):
         return self.xml_tag
 
 
-class _PropertyList(Xml, dict):
+class _PropertyList(XMLSerializable, dict):
     """
     Object used to represent Oozie workflow/coordinator property-value sets.
 
@@ -68,7 +68,7 @@ class _PropertyList(Xml, dict):
     """
 
     def __init__(self, xml_tag, attributes=None, values=None):
-        Xml.__init__(self, xml_tag)
+        XMLSerializable.__init__(self, xml_tag)
         if values:
             dict.__init__(self, values)
         else:
@@ -138,12 +138,12 @@ class Credentials(_PropertyList):
         self.name = _validate(credential_name)
 
 
-class Shell(Xml):
+class Shell(XMLSerializable):
     """Workflow shell action (v0.3)."""
 
     def __init__(self, exec_command, job_tracker=None, name_node=None, prepares=None, job_xml_files=None,
                  configuration=None, arguments=None, env_vars=None, files=None, archives=None, capture_output=False):
-        Xml.__init__(self, 'shell')
+        XMLSerializable.__init__(self, 'shell')
         self.exec_command = exec_command
         self.job_tracker = job_tracker
         self.name_node = name_node
@@ -201,7 +201,7 @@ class Shell(Xml):
         return doc
 
 
-class SubWorkflow(Xml):
+class SubWorkflow(XMLSerializable):
     """Run another workflow defined in another XML file on HDFS.
 
     An Oozie sub-workflow is an "action [that] runs a child workflow job [...]. The parent workflow job will wait
@@ -209,7 +209,7 @@ class SubWorkflow(Xml):
     """
 
     def __init__(self, app_path, propagate_configuration=True, configuration=None):
-        Xml.__init__(self, 'sub-workflow')
+        XMLSerializable.__init__(self, 'sub-workflow')
         self.app_path = app_path
         self.propagate_configuration = propagate_configuration
         self.configuration = Configuration(configuration)
@@ -226,7 +226,7 @@ class SubWorkflow(Xml):
         return doc
 
 
-class GlobalConfiguration(Xml):
+class GlobalConfiguration(XMLSerializable):
     """Global configuration values for all actions in a workflow.
 
     "Oozie allows a global section to reduce the redundant job-tracker and name-node declarations for each action.
@@ -239,7 +239,7 @@ class GlobalConfiguration(Xml):
     """
 
     def __init__(self, job_tracker='', name_node='', job_xml_files=None, configuration=None):
-        Xml.__init__(self, 'global')
+        XMLSerializable.__init__(self, 'global')
         self.job_tracker = job_tracker
         self.name_node = name_node
         self.job_xml_files = job_xml_files if job_xml_files else list()
@@ -263,11 +263,11 @@ class GlobalConfiguration(Xml):
         return doc
 
 
-class Email(Xml):
+class Email(XMLSerializable):
     """Email action for use within a workflow."""
 
     def __init__(self, to, subject, body, cc=None, bcc=None, content_type=None, attachments=None):
-        Xml.__init__(self, 'email')
+        XMLSerializable.__init__(self, 'email')
         self.to = to
         self.subject = subject
         self.body = body

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -270,7 +270,7 @@ class GlobalConfiguration(Xml):
         return doc
 
     def __nonzero__(self):
-        return any(bool(x) for x in [
+        return any(x for x in [
             self.job_tracker, self.name_node, self.job_xml_files,
             self.configuration
         ])

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -270,10 +270,7 @@ class GlobalConfiguration(Xml):
         return doc
 
     def __nonzero__(self):
-        return any(x for x in [
-            self.job_tracker, self.name_node, self.job_xml_files,
-            self.configuration
-        ])
+        return any((self.job_tracker, self.name_node, self.job_xml_files, self.configuration))
 
 
 class Email(Xml):

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -11,20 +11,13 @@ REGEX_IDENTIFIER = r'^[a-zA-Z_][\-_a-zA-Z0-9]{0,38}$'
 COMPILED_REGEX_IDENTIFIER = re.compile(REGEX_IDENTIFIER)
 
 
-class IdentifierTooLongError(AssertionError):
-
-    def __init__(self, identifier):
-        AssertionError.__init__(self, "Identifier must be less than {max_length} chars long, '{identifier}' is "
-                                "{length}".format(max_length=MAX_IDENTIFIER_LENGTH,
-                                                  identifier=identifier,
-                                                  length=len(identifier)))
-        self.length = len(identifier)
-
-
 def _validate(identifier):
 
-    if len(identifier) > MAX_IDENTIFIER_LENGTH:
-        raise IdentifierTooLongError(identifier)
+    assert len(identifier) <= MAX_IDENTIFIER_LENGTH, \
+        "Identifier must be less than {max_length} chars long, '{identifier}' is {length}".format(
+            max_length=MAX_IDENTIFIER_LENGTH,
+            identifier=identifier,
+            length=len(identifier))
 
     assert COMPILED_REGEX_IDENTIFIER.match(identifier), \
         "Identifier must match {regex}, '{identifier}' does not".format(

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -269,9 +269,6 @@ class GlobalConfiguration(Xml):
 
         return doc
 
-    def __nonzero__(self):
-        return any((self.job_tracker, self.name_node, self.job_xml_files, self.configuration))
-
 
 class Email(Xml):
     """Email action for use within a workflow."""

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -21,7 +21,7 @@ class IdentifierTooLongError(AssertionError):
         self.length = len(identifier)
 
 
-def validate(identifier):
+def _validate(identifier):
 
     if len(identifier) > MAX_IDENTIFIER_LENGTH:
         raise IdentifierTooLongError(identifier)
@@ -142,7 +142,7 @@ class Credentials(_PropertyList):
                                    'type': credential_type,
                                },
                                values=values)
-        self.name = validate(credential_name)
+        self.name = _validate(credential_name)
 
 
 class Shell(Xml):

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -238,7 +238,7 @@ class GlobalConfiguration(XMLSerializable):
     application."
     """
 
-    def __init__(self, job_tracker='', name_node='', job_xml_files=None, configuration=None):
+    def __init__(self, job_tracker=None, name_node=None, job_xml_files=None, configuration=None):
         XMLSerializable.__init__(self, 'global')
         self.job_tracker = job_tracker
         self.name_node = name_node

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -87,9 +87,9 @@ class _PropertyList(Xml, dict):
             for name, value in sorted(self.items()):
                 with tag('property'):
                     with tag('name'):
-                        doc.text(unicode(name))
+                        doc.text('%s' % name)
                     with tag('value'):
-                        doc.text(unicode(value) if value is not None else '')
+                        doc.text('%s' % value if value is not None else '')
         return doc
 
 
@@ -291,7 +291,8 @@ class Email(Xml):
 
     def _xml(self, doc, tag, text):
         def format_list(emails):
-            return ','.join(sorted(emails)) if hasattr(emails, '__iter__') else emails
+            return ','.join(sorted(emails)) if hasattr(emails, '__iter__') and not \
+                isinstance(emails, str) else emails
 
         with tag(self.xml_tag, xmlns='uri:oozie:email-action:0.2'):
             with tag('to'):

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -80,9 +80,9 @@ class _PropertyList(XMLSerializable, dict):
             for name, value in sorted(self.items()):
                 with tag('property'):
                     with tag('name'):
-                        doc.text('%s' % name)
+                        doc.text('{}'.format(name))
                     with tag('value'):
-                        doc.text('%s' % value if value is not None else '')
+                        doc.text('{}'.format(value) if value is not None else '')
         return doc
 
 
@@ -183,9 +183,9 @@ class Shell(XMLSerializable):
                 with tag('argument'):
                     doc.text(argument)
 
-            for env_var in self.env_vars.items():
+            for key, value in self.env_vars.items():
                 with tag('env-var'):
-                    doc.text('%s=%s' % env_var)
+                    doc.text('{key}={value}'.format(key=key, value=value))
 
             for filename in self.files:
                 with tag('file'):

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -80,7 +80,7 @@ class _PropertyList(Xml, dict):
             dict.__init__(self, values)
         else:
             dict.__init__(self)
-        self.attributes = attributes if attributes else dict()
+        self.attributes = attributes or {}
 
     def _xml(self, doc, tag, text):
         with tag(self.xml_tag, **self.attributes):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,10 @@
+[flake8]
+# Ignoring:
+# D100 Missing docstring in public module
+# D101 Missing docstring in public class
+# D102 Missing docstring in public method
+# D103 Missing docstring in public function
+# D104 Missing docstring in public package
+# D105 Missing docstring in magic method
+ignore=D100,D101,D102,D103,D104,D105
+max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
         'enum34>=0.9.23',
         'yattag>=1.7.2',
         'setuptools>=0.9',
-        'mock',  # TODO remove once the API calls are implemented
     ],
     license="BSD",
     keywords=['oozie'],

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         'enum34>=0.9.23',
         'yattag>=1.7.2',
         'setuptools>=0.9',
+        'mock',  # TODO remove once the API calls are implemented
     ],
     license="BSD",
     keywords=['oozie'],

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 import re
 
 
@@ -34,12 +34,12 @@ setup(
         'yattag>=1.7.2',
         'setuptools>=0.9',
     ],
-    license="BSD",
+    license="MIT",
     keywords=['oozie'],
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',
-        'License :: OSI Approved :: BSD License',
+        'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 2.7',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,11 @@
 # Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 import re
 
-from distutils.core import setup
+
+try:
+    from setuptools import setup
+except:
+    from distutils.core import setup
 
 
 with open('README.md') as fh:
@@ -15,7 +19,7 @@ with open('pyoozie/__init__.py', 'r') as fd:
 
 if not version:
     raise RuntimeError('Cannot find version information')
-    
+
 setup(
     name='pyoozie',
     version=version,
@@ -26,11 +30,12 @@ setup(
     url='https://github.com/Shopify/pyoozie',
     packages=['pyoozie'],
     install_requires=[
-        'requests>=2.12.3'
+        'enum34>=0.9.23',
+        'yattag>=1.7.2',
+        'setuptools>=0.9',
     ],
     license="BSD",
-    zip_safe=False,
-    keywords='oozie',
+    keywords=['oozie'],
     classifiers=[
         'Development Status :: 2 - Pre-Alpha',
         'Intended Audience :: Developers',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,2 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.

--- a/tests/data/coordinator-with-controls.xml
+++ b/tests/data/coordinator-with-controls.xml
@@ -1,0 +1,31 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<coordinator-app xmlns="uri:oozie:coordinator:0.5"
+                 end="2115-01-01T10:56Z"
+                 name="coordinator-name"
+                 start="2015-01-01T10:56Z"
+                 frequency="1440"
+                 timezone="UTC">
+    <parameters>
+        <property>
+            <name>throttle</name>
+            <value>1</value>
+        </property>
+    </parameters>
+    <controls>
+        <timeout>10</timeout>
+        <concurrency>1</concurrency>
+        <execution>LAST_ONLY</execution>
+        <throttle>${throttle}</throttle>
+    </controls>
+    <action>
+        <workflow>
+            <app-path>/user/oozie/workflows/descriptive-name</app-path>
+            <configuration>
+                <property>
+                    <name>mapred.job.queue.name</name>
+                    <value>production</value>
+                </property>
+            </configuration>
+        </workflow>
+    </action>
+</coordinator-app>

--- a/tests/data/coordinator.xml
+++ b/tests/data/coordinator.xml
@@ -1,0 +1,12 @@
+<coordinator-app xmlns="uri:oozie:coordinator:0.5"
+                 end="2115-01-01T10:56Z"
+                 name="coordinator-name"
+                 start="2015-01-01T10:56Z"
+                 frequency="1440"
+                 timezone="UTC">
+    <action>
+        <workflow>
+            <app-path>/user/oozie/workflows/descriptive-name</app-path>
+        </workflow>
+    </action>
+</coordinator-app>

--- a/tests/data/workflow.xml
+++ b/tests/data/workflow.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<workflow-app xmlns="uri:oozie:workflow:0.5"
+              name="descriptive-name">
+    <start to="action-payload" />
+    <action name="action-payload">
+        <shell xmlns="uri:oozie:shell-action:0.3">
+            <exec>echo "test"</exec>
+        </shell>
+        <ok to="end" />
+        <error to="action-error" />
+    </action>
+    <action name="action-error">
+        <email xmlns="uri:oozie:email-action:0.2">
+            <to>person@example.com</to>
+            <subject>Error</subject>
+            <body>A bad thing happened</body>
+        </email>
+        <ok to="kill" />
+        <error to="kill" />
+    </action>
+    <kill name="kill">
+        <message>Failure message</message>
+    </kill>
+    <end name="end" />
+</workflow-app>

--- a/tests/pyoozie/__init__.py
+++ b/tests/pyoozie/__init__.py
@@ -1,7 +1,2 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
 # Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
-import pyoozie
-
-
-def test_version():
-    assert pyoozie.__version__

--- a/tests/pyoozie/__init__.py
+++ b/tests/pyoozie/__init__.py
@@ -1,2 +1,2 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.

--- a/tests/pyoozie/conftest.py
+++ b/tests/pyoozie/conftest.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 import pytest
 
 

--- a/tests/pyoozie/conftest.py
+++ b/tests/pyoozie/conftest.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2017 "Shopify inc." All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 import pytest
 
 

--- a/tests/pyoozie/conftest.py
+++ b/tests/pyoozie/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture
+def coordinator_xml_with_controls():
+    with open('tests/data/coordinator-with-controls.xml', 'r') as fh:
+        return fh.read()

--- a/tests/pyoozie/test_builder.py
+++ b/tests/pyoozie/test_builder.py
@@ -9,8 +9,8 @@ import pytest
 from mock import Mock
 
 from tests.utils import xml_to_dict_unordered
-from pyoozie import workflow, coordinator, Shell, Email, ExecutionOrder, _workflow_submission_xml, \
-    _coordinator_submission_xml
+from pyoozie import workflow, coordinator, Shell, Email, ExecutionOrder
+from pyoozie.builder import _workflow_submission_xml, _coordinator_submission_xml
 
 
 @pytest.fixture

--- a/tests/pyoozie/test_builder.py
+++ b/tests/pyoozie/test_builder.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals
 
 from datetime import datetime

--- a/tests/pyoozie/test_builder.py
+++ b/tests/pyoozie/test_builder.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2017 "Shopify inc." All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+from __future__ import unicode_literals
+
+from datetime import datetime
+
+import pytest
+
+from mock import Mock
+
+from tests.utils import xml_to_dict_unordered
+from pyoozie import workflow, coordinator, Shell, Email, ExecutionOrder, _workflow_submission_xml, \
+    _coordinator_submission_xml
+
+
+@pytest.fixture
+def workflow_builder():
+    return workflow(
+        name='descriptive-name'
+    ).add_action(
+        name='payload',
+        action=Shell(exec_command='echo "test"'),
+        action_on_error=Email(to='person@example.com', subject='Error', body='A bad thing happened'),
+        kill_on_error='Failure message',
+    )
+
+
+@pytest.fixture
+def workflow_app_path():
+    return '/user/oozie/workflows/descriptive-name'
+
+
+@pytest.fixture
+def coord_app_path():
+    return '/user/oozie/coordinators/descriptive-name'
+
+
+@pytest.fixture
+def hadoop_user():
+    return 'test'
+
+
+def test_workflow_submission_xml(hadoop_user, workflow_app_path):
+    actual = _workflow_submission_xml(
+        hadoop_user=hadoop_user,
+        hdfs_path=workflow_app_path,
+        indent=True,
+    )
+    assert xml_to_dict_unordered('''
+    <configuration>
+        <property>
+            <name>oozie.wf.application.path</name>
+            <value>/user/oozie/workflows/descriptive-name</value>
+        </property>
+        <property>
+            <name>user.name</name>
+            <value>test</value>
+        </property>
+    </configuration>''') == xml_to_dict_unordered(actual)
+
+
+def test_workflow_submission_xml_with_configuration(hadoop_user, workflow_app_path):
+    actual = _workflow_submission_xml(
+        hadoop_user=hadoop_user,
+        hdfs_path=workflow_app_path,
+        configuration={
+            'other.key': 'other value',
+        },
+        indent=True
+    )
+
+    assert xml_to_dict_unordered('''
+    <configuration>
+        <property>
+            <name>other.key</name>
+            <value>other value</value>
+        </property>
+        <property>
+            <name>oozie.wf.application.path</name>
+            <value>/user/oozie/workflows/descriptive-name</value>
+        </property>
+        <property>
+            <name>user.name</name>
+            <value>test</value>
+        </property>
+    </configuration>''') == xml_to_dict_unordered(actual)
+
+
+def test_coordinator_submission_xml(hadoop_user, coord_app_path):
+    actual = _coordinator_submission_xml(
+        hadoop_user=hadoop_user,
+        hdfs_path=coord_app_path,
+        indent=True
+    )
+    assert xml_to_dict_unordered('''
+    <configuration>
+        <property>
+            <name>oozie.coord.application.path</name>
+            <value>/user/oozie/coordinators/descriptive-name</value>
+        </property>
+        <property>
+            <name>user.name</name>
+            <value>test</value>
+        </property>
+    </configuration>''') == xml_to_dict_unordered(actual)
+
+
+def test_coordinator_submission_xml_with_configuration(hadoop_user, coord_app_path):
+    actual = _coordinator_submission_xml(
+        hadoop_user=hadoop_user,
+        hdfs_path=coord_app_path,
+        configuration={
+            'oozie.coord.group.name': 'descriptive-group',
+        },
+        indent=True
+    )
+    assert xml_to_dict_unordered('''
+    <configuration>
+        <property>
+            <name>oozie.coord.application.path</name>
+            <value>/user/oozie/coordinators/descriptive-name</value>
+        </property>
+        <property>
+            <name>oozie.coord.group.name</name>
+            <value>descriptive-group</value>
+        </property>
+        <property>
+            <name>user.name</name>
+            <value>test</value>
+        </property>
+    </configuration>''') == xml_to_dict_unordered(actual)
+
+
+def test_workflow_builder(workflow_builder, hadoop_user, workflow_app_path):
+    with open('tests/data/workflow.xml', 'r') as fh:
+        expected = fh.read()
+
+    # Can it XML?
+    actual_xml = workflow_builder.build()
+    assert xml_to_dict_unordered(expected) == xml_to_dict_unordered(actual_xml)
+
+    # Can it dance with Oozie? (not quite)
+    mock_hdfs_callback = Mock()
+    with pytest.raises(NotImplementedError):
+        workflow_builder.submit(oozie_url='https://my.oozie.server',
+                                hadoop_user=hadoop_user,
+                                hdfs_path=workflow_app_path,
+                                hdfs_callback=mock_hdfs_callback)
+    mock_hdfs_callback.assert_called_once_with(workflow_app_path, actual_xml)
+
+
+def test_coordinator_builder(coordinator_xml_with_controls, workflow_builder, workflow_app_path, coord_app_path,
+                             hadoop_user):
+
+    coord_builder = coordinator(
+        name='coordinator-name',
+        frequency_in_minutes=24 * 60,  # In minutes
+        start=datetime(2015, 1, 1, 10, 56),
+        end=datetime(2115, 1, 1, 10, 56),
+        concurrency=1,
+        throttle='${throttle}',
+        timeout_in_minutes=10,
+        execution_order=ExecutionOrder.LAST_ONLY,
+        workflow=workflow_builder,
+        parameters={
+            'throttle': 1,
+        },
+        workflow_configuration={
+            'mapred.job.queue.name': 'production',
+        })
+
+    # Can it XML?
+    expected_xml = coord_builder.build(workflow_app_path)
+    assert xml_to_dict_unordered(coordinator_xml_with_controls) == xml_to_dict_unordered(expected_xml)
+
+    # Can it dance with Oozie? (not quite)
+
+    mock_hdfs_callback = Mock()
+    with pytest.raises(NotImplementedError):
+        coord_builder.submit(oozie_url='https://my.oozie.server',
+                             workflow_hdfs_path=workflow_app_path,
+                             coord_hdfs_path=coord_app_path,
+                             hadoop_user=hadoop_user,
+                             hdfs_callback=mock_hdfs_callback,
+                             timeout_in_seconds=5,
+                             verbose=True)
+    mock_hdfs_callback.assert_called_once_with(workflow_app_path, workflow_builder.build())
+    # TODO test that we also got to the point where we used the callback to store coordinator XML

--- a/tests/pyoozie/test_coordinator.py
+++ b/tests/pyoozie/test_coordinator.py
@@ -69,7 +69,7 @@ def test_coordinator_bad_frequency(expected_coordinator_options):
     expected_coordinator_options['frequency'] = 0
     with pytest.raises(AssertionError) as assertion_info:
         Coordinator(**expected_coordinator_options)
-    assert unicode(assertion_info.value) == \
+    assert str(assertion_info.value) == \
         'Frequency (0 min) must be greater than or equal to 5 min'
 
 
@@ -77,5 +77,5 @@ def test_coordinator_end_before_start(expected_coordinator_options):
     expected_coordinator_options['end'] = expected_coordinator_options['start'] - timedelta(days=10)
     with pytest.raises(AssertionError) as assertion_info:
         Coordinator(**expected_coordinator_options)
-    assert unicode(assertion_info.value) == \
+    assert str(assertion_info.value) == \
         'End time (2014-12-22T10:56Z) must be greater than the start time (2015-01-01T10:56Z)'

--- a/tests/pyoozie/test_coordinator.py
+++ b/tests/pyoozie/test_coordinator.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from datetime import datetime, timedelta
 
 import pytest

--- a/tests/pyoozie/test_coordinator.py
+++ b/tests/pyoozie/test_coordinator.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2017 "Shopify inc." All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+from datetime import datetime, timedelta
+
+import pytest
+
+from pyoozie import Coordinator, ExecutionOrder, Configuration, Parameters
+from tests.utils import xml_to_dict_unordered
+
+
+def parse_datetime(string):
+    return datetime.strptime(string, '%Y-%m-%dT%H:%MZ')
+
+
+@pytest.fixture
+def expected_coordinator_options():
+    return {
+        'name': 'coordinator-name',
+        'frequency': 1440,
+        'start': parse_datetime('2015-01-01T10:56Z'),
+        'end': parse_datetime('2115-01-01T10:56Z'),
+        'workflow_app_path': '/user/oozie/workflows/descriptive-name',
+    }
+
+
+@pytest.fixture
+def coordinator_xml():
+    with open('tests/data/coordinator.xml', 'r') as fh:
+        return fh.read()
+
+
+def test_coordinator(coordinator_xml, expected_coordinator_options):
+    actual = Coordinator(**expected_coordinator_options).xml()
+    assert xml_to_dict_unordered(coordinator_xml) == xml_to_dict_unordered(actual)
+
+
+def test_coordinator_end_default(coordinator_xml, expected_coordinator_options):
+    del expected_coordinator_options['end']
+    actual = Coordinator(**expected_coordinator_options).xml()
+    assert xml_to_dict_unordered(coordinator_xml) == xml_to_dict_unordered(actual)
+
+
+def test_coordinator_with_controls_and_more(coordinator_xml_with_controls, expected_coordinator_options):
+    actual = Coordinator(
+        timeout=10,
+        concurrency=1,
+        execution_order=ExecutionOrder.LAST_ONLY,
+        throttle='${throttle}',
+        workflow_configuration=Configuration({
+            'mapred.job.queue.name': 'production'
+        }),
+        parameters=Parameters({
+            'throttle': 1
+        }),
+        **expected_coordinator_options
+    ).xml()
+    assert xml_to_dict_unordered(coordinator_xml_with_controls) == xml_to_dict_unordered(actual)
+
+
+def test_really_long_coordinator_name(expected_coordinator_options):
+    with pytest.raises(AssertionError) as assertion_info:
+        del expected_coordinator_options['name']
+        Coordinator(name='long' * 10, **expected_coordinator_options)
+    assert str(assertion_info.value) == \
+        "Identifier must be less than 39 chars long, 'longlonglonglonglonglonglonglonglonglong' is 40"
+
+
+def test_coordinator_bad_frequency(expected_coordinator_options):
+    expected_coordinator_options['frequency'] = 0
+    with pytest.raises(AssertionError) as assertion_info:
+        Coordinator(**expected_coordinator_options)
+    assert unicode(assertion_info.value) == \
+        'Frequency (0 min) must be greater than or equal to 5 min'
+
+
+def test_coordinator_end_before_start(expected_coordinator_options):
+    expected_coordinator_options['end'] = expected_coordinator_options['start'] - timedelta(days=10)
+    with pytest.raises(AssertionError) as assertion_info:
+        Coordinator(**expected_coordinator_options)
+    assert unicode(assertion_info.value) == \
+        'End time (2014-12-22T10:56Z) must be greater than the start time (2015-01-01T10:56Z)'

--- a/tests/pyoozie/test_package.py
+++ b/tests/pyoozie/test_package.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 import pyoozie
 
 

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -6,8 +6,9 @@ from __future__ import unicode_literals, print_function
 import decimal
 import pytest
 
-from pyoozie import validate, Parameters, Configuration, Credentials, Shell, SubWorkflow, GlobalConfiguration, \
+from pyoozie import Parameters, Configuration, Credentials, Shell, SubWorkflow, GlobalConfiguration, \
     Email, IdentifierTooLongError
+from pyoozie.tags import _validate
 from tests.utils import xml_to_dict_unordered
 
 
@@ -63,24 +64,24 @@ def expected_property_values_xml():
 
 
 def test_validate():
-    validate('ok-id')
+    _validate('ok-id')
 
-    validate('very-long-flow-name-that-spans-39-chars')
+    _validate('very-long-flow-name-that-spans-39-chars')
 
     with pytest.raises(IdentifierTooLongError) as assertion_info:
-        validate('too-long-flow-name-that-spans-more-than-39-chars')
+        _validate('too-long-flow-name-that-spans-more-than-39-chars')
     assert str(assertion_info.value) == "Identifier must be less than 39 " \
         "chars long, 'too-long-flow-name-that-spans-more-than-39-chars' is 48"
     assert assertion_info.value.length == 48
 
     with pytest.raises(AssertionError) as assertion_info:
-        validate('0-id-starting-with-a-non-alpha-char')
+        _validate('0-id-starting-with-a-non-alpha-char')
     assert str(assertion_info.value) == "Identifier must match ^[a-zA-Z_]" \
         "[\\-_a-zA-Z0-9]{0,38}$, '0-id-starting-with-a-non-alpha-char' " \
         "does not"
 
     with pytest.raises(AssertionError) as assertion_info:
-        validate('id.with.illlegal.chars')
+        _validate('id.with.illlegal.chars')
     assert str(assertion_info.value) == "Identifier must match ^[a-zA-Z_]" \
         "[\\-_a-zA-Z0-9]{0,38}$, 'id.with.illlegal.chars' does not"
 

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -249,7 +249,7 @@ def test_email():
         to='mrt@example.com',
         subject='Chains',
         body='Do you need more?',
-        cc='ateam@ateam.com',
+        cc='ateam@example.com',
         bcc='jewelrystore@example.com',
         content_type='text/plain',
         attachments='/path/to/attachment/on/hdfs.txt',
@@ -259,7 +259,7 @@ def test_email():
         <to>mrt@example.com</to>
         <subject>Chains</subject>
         <body>Do you need more?</body>
-        <cc>ateam@ateam.com</cc>
+        <cc>ateam@example.com</cc>
         <bcc>jewelrystore@example.com</bcc>
         <content_type>text/plain</content_type>
         <attachment>/path/to/attachment/on/hdfs.txt</attachment>
@@ -270,7 +270,7 @@ def test_email():
         to=['mrt@example.com', 'b.a.baracus@example.com'],
         subject='Chains',
         body='Do you need more?',
-        cc=('ateam@ateam.com', 'webmaster@example.com'),
+        cc=('ateam@example.com', 'webmaster@example.com'),
         bcc=set(['jewelrystore@example.com', 'goldchains4u@example.com']),
         content_type='text/plain',
         attachments=['/path/on/hdfs.txt',
@@ -281,7 +281,7 @@ def test_email():
         <to>b.a.baracus@example.com,mrt@example.com</to>
         <subject>Chains</subject>
         <body>Do you need more?</body>
-        <cc>ateam@ateam.com,webmaster@example.com</cc>
+        <cc>ateam@example.com,webmaster@example.com</cc>
         <bcc>goldchains4u@example.com,jewelrystore@example.com</bcc>
         <content_type>text/plain</content_type>
         <attachment>/another/path/on/hdfs.txt,/path/on/hdfs.txt</attachment>

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals, print_function
 
 import decimal

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -86,14 +86,13 @@ def test_validate():
 
 def test_parameters(expected_property_values, expected_property_values_xml):
     actual = Parameters(expected_property_values).xml(indent=True)
-    expected = '''<parameters>%s</parameters>''' % expected_property_values_xml
+    expected = '<parameters>{xml}</parameters>'.format(xml=expected_property_values_xml)
     assert xml_to_dict_unordered(expected) == xml_to_dict_unordered(actual)
 
 
 def test_configuration(expected_property_values, expected_property_values_xml):
     actual = Configuration(expected_property_values).xml(indent=True)
-    expected = '''<configuration>%s</configuration>''' % \
-        expected_property_values_xml
+    expected = '<configuration>{xml}</configuration>'.format(xml=expected_property_values_xml)
     assert xml_to_dict_unordered(expected) == xml_to_dict_unordered(actual)
 
 
@@ -101,9 +100,8 @@ def test_credentials(expected_property_values, expected_property_values_xml):
     actual = Credentials(expected_property_values,
                          credential_name='my-hcat-creds',
                          credential_type='hcat').xml(indent=True)
-    expected = '''
-        <credentials name='my-hcat-creds' type='hcat'>%s</credentials>
-        ''' % expected_property_values_xml
+    expected = "<credentials name='my-hcat-creds' type='hcat'>{xml}</credentials>".format(
+        xml=expected_property_values_xml)
     assert xml_to_dict_unordered(expected) == xml_to_dict_unordered(actual)
 
 

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -1,0 +1,297 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2017 "Shopify inc." All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+from __future__ import unicode_literals, print_function
+
+import decimal
+import pytest
+
+from pyoozie import validate, Parameters, Configuration, Credentials, Shell, SubWorkflow, GlobalConfiguration, \
+    Email, IdentifierTooLongError
+from tests.utils import xml_to_dict_unordered
+
+
+@pytest.fixture
+def expected_property_values():
+    return {
+        'boolean': False,
+        'decimal': decimal.Decimal('0.75'),
+        'float': 0.5,
+        'int': 0,
+        'list': ['one', 'two', 'three', 'four'],
+        'long': 10,
+        'none': None,
+        'unicode': 'ǝnlɐʌ',
+        'string': str('value'),
+    }
+
+
+@pytest.fixture
+def expected_property_values_xml():
+    return '''
+        <property>
+            <name>boolean</name>
+            <value>False</value>
+        </property>
+        <property>
+            <name>decimal</name>
+            <value>0.75</value>
+        </property>
+        <property>
+            <name>float</name>
+            <value>0.5</value>
+        </property>
+        <property>
+            <name>int</name>
+            <value>0</value>
+        </property>
+        <property>
+            <name>list</name>
+            <value>[u'one', u'two', u'three', u'four']</value>
+        </property>
+        <property>
+            <name>long</name>
+            <value>10</value>
+        </property>
+        <property>
+            <name>none</name>
+            <value></value>
+        </property>
+        <property>
+            <name>string</name>
+            <value>value</value>
+        </property>
+        <property>
+            <name>unicode</name>
+            <value>ǝnlɐʌ</value>
+        </property>'''
+
+
+def test_validate():
+    validate('ok-id')
+
+    validate('very-long-flow-name-that-spans-39-chars')
+
+    with pytest.raises(IdentifierTooLongError) as assertion_info:
+        validate('too-long-flow-name-that-spans-more-than-39-chars')
+    assert str(assertion_info.value) == "Identifier must be less than 39 " \
+        "chars long, 'too-long-flow-name-that-spans-more-than-39-chars' is 48"
+    assert assertion_info.value.length == 48
+
+    with pytest.raises(AssertionError) as assertion_info:
+        validate('0-id-starting-with-a-non-alpha-char')
+    assert str(assertion_info.value) == "Identifier must match ^[a-zA-Z_]" \
+        "[\\-_a-zA-Z0-9]{0,38}$, '0-id-starting-with-a-non-alpha-char' " \
+        "does not"
+
+    with pytest.raises(AssertionError) as assertion_info:
+        validate('id.with.illlegal.chars')
+    assert str(assertion_info.value) == "Identifier must match ^[a-zA-Z_]" \
+        "[\\-_a-zA-Z0-9]{0,38}$, 'id.with.illlegal.chars' does not"
+
+
+def test_parameters(expected_property_values, expected_property_values_xml):
+    actual = Parameters(expected_property_values).xml(indent=True)
+    expected = '''<parameters>%s</parameters>''' % expected_property_values_xml
+    assert xml_to_dict_unordered(expected) == xml_to_dict_unordered(actual)
+
+
+def test_configuration(expected_property_values, expected_property_values_xml):
+    actual = Configuration(expected_property_values).xml(indent=True)
+    expected = '''<configuration>%s</configuration>''' % \
+        expected_property_values_xml
+    assert xml_to_dict_unordered(expected) == xml_to_dict_unordered(actual)
+
+
+def test_credentials(expected_property_values, expected_property_values_xml):
+    actual = Credentials(expected_property_values,
+                         credential_name='my-hcat-creds',
+                         credential_type='hcat').xml(indent=True)
+    expected = '''
+        <credentials name='my-hcat-creds' type='hcat'>%s</credentials>
+        ''' % expected_property_values_xml
+    assert xml_to_dict_unordered(expected) == xml_to_dict_unordered(actual)
+
+
+def test_shell():
+    actual = Shell(
+        exec_command='${EXEC}',
+        job_tracker='${jobTracker}',
+        name_node='${nameNode}',
+        prepares=None,
+        job_xml_files=['/user/${wf:user()}/job.xml'],
+        configuration={
+            'mapred.job.queue.name': '${queueName}'
+        },
+        arguments=['A', 'B'],
+        env_vars=None,
+        files=['/users/blabla/testfile.sh#testfile'],
+        archives=['/users/blabla/testarchive.jar#testarchive'],
+        capture_output=False
+    ).xml(indent=True)
+    assert xml_to_dict_unordered('''
+    <shell xmlns="uri:oozie:shell-action:0.3">
+        <job-tracker>${jobTracker}</job-tracker>
+        <name-node>${nameNode}</name-node>
+        <job-xml>/user/${wf:user()}/job.xml</job-xml>
+        <configuration>
+            <property>
+                <name>mapred.job.queue.name</name>
+                <value>${queueName}</value>
+            </property>
+        </configuration>
+        <exec>${EXEC}</exec>
+        <argument>A</argument>
+        <argument>B</argument>
+        <file>/users/blabla/testfile.sh#testfile</file>
+        <archive>/users/blabla/testarchive.jar#testarchive</archive>
+    </shell>''') == xml_to_dict_unordered(actual)
+
+
+def test_subworkflow():
+    app_path = '/user/username/workflows/cool-flow'
+
+    actual = SubWorkflow(
+        app_path=app_path,
+        propagate_configuration=False,
+        configuration=None,
+    ).xml(indent=True)
+    assert xml_to_dict_unordered('''
+    <sub-workflow>
+        <app-path>/user/username/workflows/cool-flow</app-path>
+    </sub-workflow>
+    ''') == xml_to_dict_unordered(actual)
+
+    actual = SubWorkflow(
+        app_path=app_path,
+        propagate_configuration=True,
+        configuration=None,
+    ).xml(indent=True)
+    assert xml_to_dict_unordered('''
+    <sub-workflow>
+        <app-path>/user/username/workflows/cool-flow</app-path>
+        <propagate-configuration />
+    </sub-workflow>
+    ''') == xml_to_dict_unordered(actual)
+
+    actual = SubWorkflow(
+        app_path=app_path,
+        propagate_configuration=True,
+        configuration={
+            'job_tracker': 'a_jobtracker',
+            'name_node': 'hdfs://localhost:50070',
+        },
+    ).xml(indent=True)
+    assert xml_to_dict_unordered('''
+    <sub-workflow>
+        <app-path>/user/username/workflows/cool-flow</app-path>
+        <propagate-configuration />
+        <configuration>
+            <property>
+                <name>job_tracker</name>
+                <value>a_jobtracker</value>
+            </property>
+            <property>
+                <name>name_node</name>
+                <value>hdfs://localhost:50070</value>
+            </property>
+        </configuration>
+    </sub-workflow>
+    ''') == xml_to_dict_unordered(actual)
+
+
+def test_global_configuration():
+    configuration = {
+        'mapred.job.queue.name': '${queueName}'
+    }
+
+    actual = GlobalConfiguration(
+        job_tracker='a_jobtracker',
+        name_node='hdfs://localhost:50070',
+        job_xml_files=None,
+        configuration=None,
+    ).xml(indent=True)
+    assert xml_to_dict_unordered('''
+    <global>
+        <job-tracker>a_jobtracker</job-tracker>
+        <name-node>hdfs://localhost:50070</name-node>
+    </global>
+    ''') == xml_to_dict_unordered(actual)
+
+    actual = GlobalConfiguration(
+        job_tracker='a_jobtracker',
+        name_node='hdfs://localhost:50070',
+        job_xml_files=['/user/${wf:user()}/job.xml'],
+        configuration=configuration,
+    ).xml(indent=True)
+    assert xml_to_dict_unordered('''
+    <global>
+        <job-tracker>a_jobtracker</job-tracker>
+        <name-node>hdfs://localhost:50070</name-node>
+        <job-xml>/user/${wf:user()}/job.xml</job-xml>
+        <configuration>
+            <property>
+                <name>mapred.job.queue.name</name>
+                <value>${queueName}</value>
+            </property>
+        </configuration>
+    </global>
+    ''') == xml_to_dict_unordered(actual)
+
+
+def test_email():
+    actual = Email(
+        to='mrt@theateam.com',
+        subject='Chains',
+        body='Do you need more?',
+    ).xml(indent=True)
+    assert xml_to_dict_unordered('''
+    <email xmlns="uri:oozie:email-action:0.2">
+        <to>mrt@theateam.com</to>
+        <subject>Chains</subject>
+        <body>Do you need more?</body>
+    </email>
+    ''') == xml_to_dict_unordered(actual)
+
+    actual = Email(
+        to='mrt@theateam.com',
+        subject='Chains',
+        body='Do you need more?',
+        cc='ateam@ateam.com',
+        bcc='jewelrystore@myshopify.com',
+        content_type='text/plain',
+        attachments='/path/to/attachment/on/hdfs.txt',
+    ).xml(indent=True)
+    assert xml_to_dict_unordered('''
+    <email xmlns="uri:oozie:email-action:0.2">
+        <to>mrt@theateam.com</to>
+        <subject>Chains</subject>
+        <body>Do you need more?</body>
+        <cc>ateam@ateam.com</cc>
+        <bcc>jewelrystore@myshopify.com</bcc>
+        <content_type>text/plain</content_type>
+        <attachment>/path/to/attachment/on/hdfs.txt</attachment>
+    </email>
+    ''') == xml_to_dict_unordered(actual)
+
+    actual = Email(
+        to=['mrt@theateam.com', 'b.a.baracus@theateam.com'],
+        subject='Chains',
+        body='Do you need more?',
+        cc=('ateam@ateam.com', 'webmaster@theateam.com'),
+        bcc=set(['jewelrystore@myshopify.com', 'goldchains4u@myshopify.com']),
+        content_type='text/plain',
+        attachments=['/path/on/hdfs.txt',
+                     '/another/path/on/hdfs.txt'],
+    ).xml(indent=True)
+    assert xml_to_dict_unordered('''
+    <email xmlns="uri:oozie:email-action:0.2">
+        <to>b.a.baracus@theateam.com,mrt@theateam.com</to>
+        <subject>Chains</subject>
+        <body>Do you need more?</body>
+        <cc>ateam@ateam.com,webmaster@theateam.com</cc>
+        <bcc>goldchains4u@myshopify.com,jewelrystore@myshopify.com</bcc>
+        <content_type>text/plain</content_type>
+        <attachment>/another/path/on/hdfs.txt,/path/on/hdfs.txt</attachment>
+    </email>
+    ''') == xml_to_dict_unordered(actual)

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -18,7 +18,6 @@ def expected_property_values():
         'decimal': decimal.Decimal('0.75'),
         'float': 0.5,
         'int': 0,
-        'list': ['one', 'two', 'three', 'four'],
         'long': 10,
         'none': None,
         'unicode': 'ǝnlɐʌ',
@@ -44,10 +43,6 @@ def expected_property_values_xml():
         <property>
             <name>int</name>
             <value>0</value>
-        </property>
-        <property>
-            <name>list</name>
-            <value>[u'one', u'two', u'three', u'four']</value>
         </property>
         <property>
             <name>long</name>

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -6,8 +6,7 @@ from __future__ import unicode_literals, print_function
 import decimal
 import pytest
 
-from pyoozie import Parameters, Configuration, Credentials, Shell, SubWorkflow, GlobalConfiguration, \
-    Email, IdentifierTooLongError
+from pyoozie import Parameters, Configuration, Credentials, Shell, SubWorkflow, GlobalConfiguration, Email
 from pyoozie.tags import _validate
 from tests.utils import xml_to_dict_unordered
 
@@ -68,11 +67,10 @@ def test_validate():
 
     _validate('very-long-flow-name-that-spans-39-chars')
 
-    with pytest.raises(IdentifierTooLongError) as assertion_info:
+    with pytest.raises(AssertionError) as assertion_info:
         _validate('too-long-flow-name-that-spans-more-than-39-chars')
     assert str(assertion_info.value) == "Identifier must be less than 39 " \
         "chars long, 'too-long-flow-name-that-spans-more-than-39-chars' is 48"
-    assert assertion_info.value.length == 48
 
     with pytest.raises(AssertionError) as assertion_info:
         _validate('0-id-starting-with-a-non-alpha-char')

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -235,56 +235,56 @@ def test_global_configuration():
 
 def test_email():
     actual = Email(
-        to='mrt@theateam.com',
+        to='mrt@example.com',
         subject='Chains',
         body='Do you need more?',
     ).xml(indent=True)
     assert xml_to_dict_unordered('''
     <email xmlns="uri:oozie:email-action:0.2">
-        <to>mrt@theateam.com</to>
+        <to>mrt@example.com</to>
         <subject>Chains</subject>
         <body>Do you need more?</body>
     </email>
     ''') == xml_to_dict_unordered(actual)
 
     actual = Email(
-        to='mrt@theateam.com',
+        to='mrt@example.com',
         subject='Chains',
         body='Do you need more?',
         cc='ateam@ateam.com',
-        bcc='jewelrystore@myshopify.com',
+        bcc='jewelrystore@example.com',
         content_type='text/plain',
         attachments='/path/to/attachment/on/hdfs.txt',
     ).xml(indent=True)
     assert xml_to_dict_unordered('''
     <email xmlns="uri:oozie:email-action:0.2">
-        <to>mrt@theateam.com</to>
+        <to>mrt@example.com</to>
         <subject>Chains</subject>
         <body>Do you need more?</body>
         <cc>ateam@ateam.com</cc>
-        <bcc>jewelrystore@myshopify.com</bcc>
+        <bcc>jewelrystore@example.com</bcc>
         <content_type>text/plain</content_type>
         <attachment>/path/to/attachment/on/hdfs.txt</attachment>
     </email>
     ''') == xml_to_dict_unordered(actual)
 
     actual = Email(
-        to=['mrt@theateam.com', 'b.a.baracus@theateam.com'],
+        to=['mrt@example.com', 'b.a.baracus@example.com'],
         subject='Chains',
         body='Do you need more?',
-        cc=('ateam@ateam.com', 'webmaster@theateam.com'),
-        bcc=set(['jewelrystore@myshopify.com', 'goldchains4u@myshopify.com']),
+        cc=('ateam@ateam.com', 'webmaster@example.com'),
+        bcc=set(['jewelrystore@example.com', 'goldchains4u@example.com']),
         content_type='text/plain',
         attachments=['/path/on/hdfs.txt',
                      '/another/path/on/hdfs.txt'],
     ).xml(indent=True)
     assert xml_to_dict_unordered('''
     <email xmlns="uri:oozie:email-action:0.2">
-        <to>b.a.baracus@theateam.com,mrt@theateam.com</to>
+        <to>b.a.baracus@example.com,mrt@example.com</to>
         <subject>Chains</subject>
         <body>Do you need more?</body>
-        <cc>ateam@ateam.com,webmaster@theateam.com</cc>
-        <bcc>goldchains4u@myshopify.com,jewelrystore@myshopify.com</bcc>
+        <cc>ateam@ateam.com,webmaster@example.com</cc>
+        <bcc>goldchains4u@example.com,jewelrystore@example.com</bcc>
         <content_type>text/plain</content_type>
         <attachment>/another/path/on/hdfs.txt,/path/on/hdfs.txt</attachment>
     </email>

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,16 @@
+# Copyright (c) 2017 "Shopify inc." All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+from __future__ import unicode_literals, print_function
+
+import xmltodict
+
+
+def xml_to_dict_unordered(xml):
+    def unorder(value):
+        if hasattr(value, 'items'):
+            return {k: unorder(v) for k, v in value.items()}
+        elif isinstance(value, list):
+            return sorted([unorder(v) for v in value])
+        else:
+            return value
+    return unorder(xmltodict.parse(xml))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,5 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
-# Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals, print_function
 
 import xmltodict

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,7 +10,7 @@ def xml_to_dict_unordered(xml):
         if hasattr(value, 'items'):
             return {k: unorder(v) for k, v in value.items()}
         elif isinstance(value, list):
-            return sorted([unorder(v) for v in value])
+            return sorted([unorder(v) for v in value], key=str)
         else:
             return value
     return unorder(xmltodict.parse(xml))


### PR DESCRIPTION
This PR adds basic XML tag generation for Python 2 and 3 and a basic builder-interface that could be used to submit a simple workflow.

This PR leaves out:
  - Documentation and a clear delineation of the public vs private APIs
  - The actual Oozie API calls

https://github.com/Shopify/pyoozie/issues/3 documents non-implementation details that need to be fixed before releasing.

This PR should serve as a basis for adding Oozie API calls in a future PR.

review/ @honkfestival @kmtaylor-github 