### PR TITLE
Add validation on action names

### DIFF
--- a/pyoozie/builder.py
+++ b/pyoozie/builder.py
@@ -3,7 +3,7 @@
 from __future__ import unicode_literals
 
 from pyoozie.coordinator import Coordinator
-from pyoozie.tags import Configuration
+from pyoozie.tags import Configuration, _validate
 
 
 def _workflow_submission_xml(username, workflow_xml_path, configuration=None, indent=False):
@@ -42,7 +42,7 @@ class WorkflowBuilder(object):
         if any((self._action_name, self._action_payload, self._action_error, self._kill_message)):
             raise NotImplementedError("Can only add one action in this version")
         else:
-            self._action_name = name
+            self._action_name = _validate(name)
             self._action_payload = action
             self._action_error = action_on_error
             self._kill_message = kill_on_error

--- a/tests/pyoozie/test_builder.py
+++ b/tests/pyoozie/test_builder.py
@@ -134,6 +134,29 @@ def test_workflow_builder():
     actual_xml = builder.build()
     assert xml_to_dict_unordered(expected) == xml_to_dict_unordered(actual_xml)
 
+    # Does it throw an exception on a bad name?
+    with pytest.raises(AssertionError) as assertion_info:
+        WorkflowBuilder(
+            name='descriptive-name'
+        ).add_action(
+            name='Name with invalid characters',
+            action=Shell(exec_command='echo "test"'),
+            action_on_error=Email(to='person@example.com', subject='Error', body='A bad thing happened'),
+            kill_on_error='Failure message',
+        )
+    assert str(assertion_info.value) == \
+        "Identifier must match ^[a-zA-Z_][\\-_a-zA-Z0-9]{0,38}$, 'Name with invalid characters' does not"
+
+    # Does it raise an exception when you try to add multiple actions?
+    with pytest.raises(NotImplementedError) as assertion_info:
+        builder.add_action(
+            name='payload',
+            action=Shell(exec_command='echo "test"'),
+            action_on_error=Email(to='person@example.com', subject='Error', body='A bad thing happened'),
+            kill_on_error='Failure message',
+        )
+    assert str(assertion_info.value) == 'Can only add one action in this version'
+
 
 def test_coordinator_builder(coordinator_xml_with_controls, workflow_app_path):
 

--- a/tests/pyoozie/test_builder.py
+++ b/tests/pyoozie/test_builder.py
@@ -147,16 +147,6 @@ def test_workflow_builder():
     assert str(assertion_info.value) == \
         "Identifier must match ^[a-zA-Z_][\\-_a-zA-Z0-9]{0,38}$, 'Name with invalid characters' does not"
 
-    # Does it raise an exception when you try to add multiple actions?
-    with pytest.raises(NotImplementedError) as assertion_info:
-        builder.add_action(
-            name='payload',
-            action=Shell(exec_command='echo "test"'),
-            action_on_error=Email(to='person@example.com', subject='Error', body='A bad thing happened'),
-            kill_on_error='Failure message',
-        )
-    assert str(assertion_info.value) == 'Can only add one action in this version'
-
 
 def test_coordinator_builder(coordinator_xml_with_controls, workflow_app_path):
 


### PR DESCRIPTION
Oozie [workflow action names are identifiers](https://github.com/apache/oozie/blob/35db5b31fa0c69680de4fe12eabc6fde818b2c54/client/src/main/resources/oozie-workflow-0.5.xsd#L159), and identifiers must conform to [`([a-zA-Z_]([\-_a-zA-Z0-9])*){1,39}`](https://github.com/apache/oozie/blob/35db5b31fa0c69680de4fe12eabc6fde818b2c54/client/src/main/resources/oozie-workflow-0.5.xsd#L26). This PR adds this enforcement.

review/ @honkfestival @kmtaylor-github 