### PR TITLE
Add workflow XML validation to test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 htmlcov
 .coverage
 .cache
+oozie/*

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@
 htmlcov
 .coverage
 .cache
-oozie/*
+lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,7 @@ script:
   - make lint
 notifications:
   email: false
+addons:
+  apt:
+    packages:
+      openjdk-7-jdk

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,11 @@ clean:
 install:
 		pip install -e .
 		pip install -r dev_requirements.txt
-		test ! -d oozie/oozie-4.1.0/lib && \
-			mkdir -p oozie/oozie-4.1.0/lib && \
-			curl http://central.maven.org/maven2/org/apache/oozie/oozie-client/4.1.0/oozie-client-4.1.0.jar -o oozie/oozie-4.1.0/lib/oozie-client-4.1.0.jar && \
-			curl http://central.maven.org/maven2/commons-cli/commons-cli/1.2/commons-cli-1.2.jar -o oozie/oozie-4.1.0/lib/commons-cli-1.2.jar
+		test -d lib || mkdir lib
+		test -f lib/oozie-client-4.1.0.jar || \
+			curl http://central.maven.org/maven2/org/apache/oozie/oozie-client/4.1.0/oozie-client-4.1.0.jar -o lib/oozie-client-4.1.0.jar
+		test -f lib/commons-cli-1.2.jar || \
+			curl http://central.maven.org/maven2/commons-cli/commons-cli/1.2/commons-cli-1.2.jar -o lib/commons-cli-1.2.jar
 
 test: clean
 		py.test -vv --durations=10 --cov=pyoozie

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ clean:
 install:
 		pip install -e .
 		pip install -r dev_requirements.txt
+		test ! -d oozie/oozie-4.1.0/lib && \
+			mkdir -p oozie/oozie-4.1.0/lib && \
+			curl http://central.maven.org/maven2/org/apache/oozie/oozie-client/4.1.0/oozie-client-4.1.0.jar -o oozie/oozie-4.1.0/lib/oozie-client-4.1.0.jar && \
+			curl http://central.maven.org/maven2/commons-cli/commons-cli/1.2/commons-cli-1.2.jar -o oozie/oozie-4.1.0/lib/commons-cli-1.2.jar
 
 test: clean
 		py.test -vv --durations=10 --cov=pyoozie

--- a/tests/pyoozie/test_builder.py
+++ b/tests/pyoozie/test_builder.py
@@ -1,14 +1,16 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
-from __future__ import unicode_literals
+from __future__ import unicode_literals, print_function
+
+import subprocess
 
 from datetime import datetime
 
 import pytest
 
-from tests.utils import xml_to_dict_unordered
 from pyoozie import WorkflowBuilder, CoordinatorBuilder, Shell, Email, ExecutionOrder
 from pyoozie.builder import _workflow_submission_xml, _coordinator_submission_xml
+from tests.utils import xml_to_dict_unordered
 
 
 @pytest.fixture
@@ -117,9 +119,9 @@ def test_coordinator_submission_xml_with_configuration(username, coord_app_path)
     </configuration>''') == xml_to_dict_unordered(actual)
 
 
-def test_workflow_builder():
+def test_workflow_builder(tmpdir, request):
     with open('tests/data/workflow.xml', 'r') as fh:
-        expected = fh.read()
+        expected_xml = fh.read()
 
     # Can it XML?
     builder = WorkflowBuilder(
@@ -131,8 +133,25 @@ def test_workflow_builder():
         kill_on_error='Failure message',
     )
 
+    # Is this XML expected
     actual_xml = builder.build()
-    assert xml_to_dict_unordered(expected) == xml_to_dict_unordered(actual_xml)
+    assert xml_to_dict_unordered(expected_xml) == xml_to_dict_unordered(actual_xml)
+
+    # Does it validate against the workflow XML schema?
+    try:
+        filename = tmpdir.join("workflow.xml")
+        filename.write_text(actual_xml, encoding='utf8')
+        subprocess.check_output(
+            'java -cp oozie/oozie-4.1.0/lib/oozie-client-4.1.0.jar:oozie/oozie-4.1.0/lib/commons-cli-1.2.jar '
+            'org.apache.oozie.cli.OozieCLI validate {path}'.format(path=str(filename)),
+            stderr=subprocess.STDOUT,
+            shell=True
+        )
+    except subprocess.CalledProcessError as e:
+        if request.config.getoption('verbose') > 0:
+            print(actual_xml)
+            print(e.output)
+        raise AssertionError('Invalid XML')
 
     # Does it throw an exception on a bad name?
     with pytest.raises(AssertionError) as assertion_info:

--- a/tests/pyoozie/test_builder.py
+++ b/tests/pyoozie/test_builder.py
@@ -119,7 +119,7 @@ def test_coordinator_submission_xml_with_configuration(username, coord_app_path)
     </configuration>''') == xml_to_dict_unordered(actual)
 
 
-def test_workflow_builder(tmpdir, request):
+def test_workflow_builder(tmpdir):
     with open('tests/data/workflow.xml', 'r') as fh:
         expected_xml = fh.read()
 
@@ -148,10 +148,10 @@ def test_workflow_builder(tmpdir, request):
             shell=True
         )
     except subprocess.CalledProcessError as e:
-        if request.config.getoption('verbose') > 0:
-            print(actual_xml)
-            print(e.output)
-        raise AssertionError('Invalid XML')
+        raise AssertionError('An XML validation error\n\n{error}\n\noccurred while parsing:\n\n{xml}'.format(
+            error=e.output.decode('utf8').strip(),
+            xml=actual_xml,
+        ))
 
     # Does it throw an exception on a bad name?
     with pytest.raises(AssertionError) as assertion_info:

--- a/tests/pyoozie/test_builder.py
+++ b/tests/pyoozie/test_builder.py
@@ -142,7 +142,7 @@ def test_workflow_builder(tmpdir, request):
         filename = tmpdir.join("workflow.xml")
         filename.write_text(actual_xml, encoding='utf8')
         subprocess.check_output(
-            'java -cp oozie/oozie-4.1.0/lib/oozie-client-4.1.0.jar:oozie/oozie-4.1.0/lib/commons-cli-1.2.jar '
+            'java -cp lib/oozie-client-4.1.0.jar:lib/commons-cli-1.2.jar '
             'org.apache.oozie.cli.OozieCLI validate {path}'.format(path=str(filename)),
             stderr=subprocess.STDOUT,
             shell=True


### PR DESCRIPTION
This PR adds the ability to validate that the workflow XML that's generated against the [workflow XML schema](https://github.com/apache/oozie/blob/master/client/src/main/resources/oozie-workflow-0.5.xsd) using [`oozie validate`](https://oozie.apache.org/docs/4.1.0/DG_CommandLineTool.html#Validating_a_Workflow_XML) (for which the minimum set of binaries required are provided via `make install`).

Violations fail the test and if verbosity is turned on will print the XML that was tested and the validation error from the script, e.g.:
```
        except subprocess.CalledProcessError as e:
            raise AssertionError('An XML validation error\n\n{error}\n\noccurred while parsing:\n\n{xml}'.format(
                error=e.output.decode('utf8').strip(),
>               xml=actual_xml,
            ))
E           AssertionError: An XML validation error
E
E           Error: Invalid app definition, org.xml.sax.SAXParseException; lineNumber: 5; columnNumber: 29; cvc-complex-type.2.4.a: Invalid content was found starting with element 'bad'. One of '{"uri:oozie:workflow:0.5":decision, "uri:oozie:workflow:0.5":fork, "uri:oozie:workflow:0.5":join, "uri:oozie:workflow:0.5":kill, "uri:oozie:workflow:0.5":action, "uri:oozie:workflow:0.5":end}' is expected.
E
E           occurred while parsing:
E
E           <?xml version="1.0" encoding="UTF-8"?>
E           <workflow-app xmlns="uri:oozie:workflow:0.5"
E                         name="descriptive-name">
E               <start to="action-payload" />
E               <action name="action-payload">
E                   <shell xmlns="uri:oozie:shell-action:0.3"><exec>echo "test"</exec></shell>
E                   <ok to="end" />
E                   <error to="action-error" />
E               </action>
E               <action name="action-error">
E                   <email xmlns="uri:oozie:email-action:0.2"><to>person@example.com</to><subject>Error</subject><body>A bad thing happened</body></email>
E                   <ok to="kill" />
E                   <error to="kill" />
E               </action>
E               <kill name="kill">
E                   <message>Failure message</message>
E               </kill>
E               <end name="end" />
E           </workflow-app>

tests/pyoozie/test_builder.py:153: AssertionError
```

To make this work, we need to download some JARs on `make install`. I've placed them in `lib/*` to match what the Oozie distribution looks like (those JARs are usually located in `<oozie location>/lib`).

review/ @kmtaylor-github @JasonMWhite 