### PR TITLE
Add shopify_python linter and adhere to import-modules-only rule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ python:
    - "3.3"
    - "3.4"
    - "3.5"
-   - "3.6"
 before_install:
   - pip install -U pip setuptools
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ python:
    - "3.4"
    - "3.5"
    - "3.6"
+before_install:
+  - pip install -U pip setuptools
 install:
   - make install
 script:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ clean:
 		rm -fr *.egg-info
 
 install:
-		pip install -e ".[test]"
+		pip install -e ".[test]" --process-dependency-links
 		test -d lib || mkdir lib
 		test -f lib/oozie-client-4.1.0.jar || \
 			curl http://central.maven.org/maven2/org/apache/oozie/oozie-client/4.1.0/oozie-client-4.1.0.jar -o lib/oozie-client-4.1.0.jar

--- a/pylintrc
+++ b/pylintrc
@@ -19,7 +19,7 @@ persistent=yes
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=
+load-plugins=shopify_python
 
 
 [MESSAGES CONTROL]
@@ -50,9 +50,10 @@ load-plugins=
 # D101 Missing docstring in public class
 # D102 Missing docstring in public method
 # D105 Missing docstring in magic method
+# global-variable; too many violations at present
 disable=C0111,D101,D102,D105,too-few-public-methods,too-many-instance-attributes,too-many-arguments,
  protected-access,invalid-name,redefined-outer-name,no-self-use,too-many-public-methods,too-many-lines,
- duplicate-code,fixme
+ duplicate-code,fixme,global-variable
 
 
 

--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals
 
+# pylint: disable=import-modules-only
 from pyoozie.builder import WorkflowBuilder, CoordinatorBuilder
 from pyoozie.client import OozieClient
 from pyoozie.coordinator import Coordinator, ExecutionOrder

--- a/pyoozie/builder.py
+++ b/pyoozie/builder.py
@@ -2,13 +2,13 @@
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals
 
-from pyoozie.coordinator import Coordinator
-from pyoozie.tags import Configuration, _validate_id, _validate_name
+from pyoozie import coordinator
+from pyoozie import tags
 
 
 def _workflow_submission_xml(username, workflow_xml_path, configuration=None, indent=False):
     """Generate a Workflow XML submission message to POST to Oozie."""
-    submission = Configuration(configuration)
+    submission = tags.Configuration(configuration)
     submission.update({
         'user.name': username,
         'oozie.wf.application.path': workflow_xml_path,
@@ -18,7 +18,7 @@ def _workflow_submission_xml(username, workflow_xml_path, configuration=None, in
 
 def _coordinator_submission_xml(username, coord_xml_path, configuration=None, indent=False):
     """Generate a Coordinator XML submission message to POST to Oozie."""
-    submission = Configuration(configuration)
+    submission = tags.Configuration(configuration)
     submission.update({
         'user.name': username,
         'oozie.coord.application.path': coord_xml_path,
@@ -30,7 +30,7 @@ class WorkflowBuilder(object):
 
     def __init__(self, name):
         # Initially, let's just use a static template and only one action payload and one action on error
-        self._name = _validate_name(name)
+        self._name = tags._validate_name(name)
         self._action_name = None
         self._action_payload = None
         self._action_error = None
@@ -42,7 +42,7 @@ class WorkflowBuilder(object):
         if any((self._action_name, self._action_payload, self._action_error, self._kill_message)):
             raise NotImplementedError("Can only add one action in this version")
         else:
-            self._action_name = _validate_id('action-' + name)
+            self._action_name = tags._validate_id('action-' + name)
             self._action_payload = action
             self._action_error = action_on_error
             self._kill_message = kill_on_error
@@ -85,7 +85,7 @@ class CoordinatorBuilder(object):
     def __init__(self, name, workflow_xml_path, frequency_in_minutes, start, end=None, timezone=None,
                  workflow_configuration=None, timeout_in_minutes=None, concurrency=None, execution_order=None,
                  throttle=None, parameters=None):
-        self._coordinator = Coordinator(
+        self._coordinator = coordinator.Coordinator(
             name=name,
             workflow_app_path=workflow_xml_path,
             frequency=frequency_in_minutes,

--- a/pyoozie/coordinator.py
+++ b/pyoozie/coordinator.py
@@ -2,16 +2,16 @@
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals
 
-from datetime import timedelta
-from enum import Enum
+import datetime
+import enum
 
-from pyoozie.tags import _validate_name, XMLSerializable, Parameters, Configuration
+from pyoozie import tags
 
 
 ONE_HUNDRED_YEARS = 100 * 365.24
 
 
-class ExecutionOrder(Enum):
+class ExecutionOrder(enum.Enum):
     """Execution order used for coordinator jobs."""
 
     FIFO = 'FIFO'
@@ -27,7 +27,7 @@ def format_datetime(value):
     return value.strftime('%Y-%m-%dT%H:%MZ')
 
 
-class Coordinator(XMLSerializable):
+class Coordinator(tags.XMLSerializable):
 
     def __init__(self, name, workflow_app_path, frequency, start, end=None, timezone=None,
                  workflow_configuration=None, timeout=None, concurrency=None, execution_order=None, throttle=None,
@@ -35,14 +35,14 @@ class Coordinator(XMLSerializable):
         super(Coordinator, self).__init__('coordinator-app')
         # Compose and validate dates/frequencies
         if end is None:
-            end = start + timedelta(days=ONE_HUNDRED_YEARS)
+            end = start + datetime.timedelta(days=ONE_HUNDRED_YEARS)
         assert end > start, "End time ({end}) must be greater than the start time ({start})".format(
             end=format_datetime(end), start=format_datetime(start))
         assert frequency >= 5, "Frequency ({frequency} min) must be greater than or equal to 5 min".format(
             frequency=frequency)
 
         # Coordinator
-        self.name = _validate_name(name)
+        self.name = tags._validate_name(name)
         self.frequency = frequency
         self.start = start
         self.end = end
@@ -50,7 +50,7 @@ class Coordinator(XMLSerializable):
 
         # Workflow action
         self.workflow_app_path = workflow_app_path
-        self.workflow_configuration = Configuration(workflow_configuration)
+        self.workflow_configuration = tags.Configuration(workflow_configuration)
 
         # Controls
         self.timeout = timeout
@@ -58,7 +58,7 @@ class Coordinator(XMLSerializable):
         self.execution_order = execution_order
         self.throttle = throttle
 
-        self.parameters = Parameters(parameters)
+        self.parameters = tags.Parameters(parameters)
 
     def _xml(self, doc, tag, text):
         with tag(self.xml_tag, xmlns="uri:oozie:coordinator:0.4", name=self.name, frequency=str(self.frequency),

--- a/pyoozie/model.py
+++ b/pyoozie/model.py
@@ -4,8 +4,9 @@ from __future__ import unicode_literals
 
 import collections
 import datetime
-import enum
 import re
+
+import enum
 import untangle
 
 from pyoozie import exceptions

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals
-from abc import ABCMeta, abstractmethod
+import abc
 import re
 import string  # pylint: disable=deprecated-module
 import yattag
@@ -44,7 +44,7 @@ def _validate_id(identifier):
 class XMLSerializable(object):
     """An abstract object that can be serialized to XML."""
 
-    __metaclass__ = ABCMeta
+    __metaclass__ = abc.ABCMeta
 
     def __init__(self, xml_tag):
         self.xml_tag = xml_tag
@@ -58,7 +58,7 @@ class XMLSerializable(object):
         else:
             return xml
 
-    @abstractmethod
+    @abc.abstractmethod
     def _xml(self, doc, tag, text):
         raise NotImplementedError()
 

--- a/setup.py
+++ b/setup.py
@@ -50,8 +50,12 @@ setup(
             'pytest>=2.7',
             'requests-mock',
             'xmltodict',
+            'shopify_python==0.1.2',
         ],
     },
+    dependency_links=[
+        'https://github.com/Shopify/shopify_python/zipball/v0.1.2#egg=shopify_python-0.1.2',
+    ],
     license="MIT",
     keywords=['oozie'],
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         ],
     },
     dependency_links=[
-        'https://github.com/Shopify/shopify_python/zipball/v0.1.2#egg=shopify_python-0.1.2',
+        'git+https://github.com/Shopify/shopify_python.git@v0.1.2#egg=shopify_python-0.1.2',
     ],
     license="MIT",
     keywords=['oozie'],

--- a/tests/pyoozie/test_builder.py
+++ b/tests/pyoozie/test_builder.py
@@ -230,5 +230,6 @@ def test_coordinator_builder(coordinator_xml_with_controls, workflow_app_path):
 
     # Can it XML?
     expected_xml = coord_builder.build()
-    assert tests.utils.xml_to_dict_unordered(coordinator_xml_with_controls) == \
-        tests.utils.xml_to_dict_unordered(expected_xml)
+    actual_dict = tests.utils.xml_to_dict_unordered(coordinator_xml_with_controls)
+    expected_dict = tests.utils.xml_to_dict_unordered(expected_xml)
+    assert actual_dict == expected_dict

--- a/tests/pyoozie/test_coordinator.py
+++ b/tests/pyoozie/test_coordinator.py
@@ -1,16 +1,16 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
-from datetime import datetime, timedelta
+import datetime
 
 import pytest
+import tests.utils
 
-from pyoozie.coordinator import Coordinator, ExecutionOrder, Configuration, Parameters
-from pyoozie.tags import MAX_NAME_LENGTH
-from tests.utils import xml_to_dict_unordered
+from pyoozie import coordinator
+from pyoozie import tags
 
 
 def parse_datetime(string):
-    return datetime.strptime(string, '%Y-%m-%dT%H:%MZ')
+    return datetime.datetime.strptime(string, '%Y-%m-%dT%H:%MZ')
 
 
 @pytest.fixture
@@ -31,51 +31,52 @@ def coordinator_xml():
 
 
 def test_coordinator(coordinator_xml, expected_coordinator_options):
-    actual = Coordinator(**expected_coordinator_options).xml()
-    assert xml_to_dict_unordered(coordinator_xml) == xml_to_dict_unordered(actual)
+    actual = coordinator.Coordinator(**expected_coordinator_options).xml()
+    assert tests.utils.xml_to_dict_unordered(coordinator_xml) == tests.utils.xml_to_dict_unordered(actual)
 
 
 def test_coordinator_end_default(coordinator_xml, expected_coordinator_options):
     del expected_coordinator_options['end']
-    actual = Coordinator(**expected_coordinator_options).xml()
-    assert xml_to_dict_unordered(coordinator_xml) == xml_to_dict_unordered(actual)
+    actual = coordinator.Coordinator(**expected_coordinator_options).xml()
+    assert tests.utils.xml_to_dict_unordered(coordinator_xml) == tests.utils.xml_to_dict_unordered(actual)
 
 
 def test_coordinator_with_controls_and_more(coordinator_xml_with_controls, expected_coordinator_options):
-    actual = Coordinator(
+    actual = coordinator.Coordinator(
         timeout=10,
         concurrency=1,
-        execution_order=ExecutionOrder.LAST_ONLY,
+        execution_order=coordinator.ExecutionOrder.LAST_ONLY,
         throttle='${throttle}',
-        workflow_configuration=Configuration({
+        workflow_configuration=tags.Configuration({
             'mapred.job.queue.name': 'production'
         }),
-        parameters=Parameters({
+        parameters=tags.Parameters({
             'throttle': 1
         }),
         **expected_coordinator_options
     ).xml()
-    assert xml_to_dict_unordered(coordinator_xml_with_controls) == xml_to_dict_unordered(actual)
+    assert tests.utils.xml_to_dict_unordered(coordinator_xml_with_controls) == \
+        tests.utils.xml_to_dict_unordered(actual)
 
 
 def test_really_long_coordinator_name(expected_coordinator_options):
     with pytest.raises(AssertionError) as assertion_info:
         del expected_coordinator_options['name']
-        Coordinator(name='l' * (MAX_NAME_LENGTH + 1), **expected_coordinator_options)
+        coordinator.Coordinator(name='l' * (tags.MAX_NAME_LENGTH + 1), **expected_coordinator_options)
     assert "Name must be less than" in str(assertion_info.value)
 
 
 def test_coordinator_bad_frequency(expected_coordinator_options):
     expected_coordinator_options['frequency'] = 0
     with pytest.raises(AssertionError) as assertion_info:
-        Coordinator(**expected_coordinator_options)
+        coordinator.Coordinator(**expected_coordinator_options)
     assert str(assertion_info.value) == \
         'Frequency (0 min) must be greater than or equal to 5 min'
 
 
 def test_coordinator_end_before_start(expected_coordinator_options):
-    expected_coordinator_options['end'] = expected_coordinator_options['start'] - timedelta(days=10)
+    expected_coordinator_options['end'] = expected_coordinator_options['start'] - datetime.timedelta(days=10)
     with pytest.raises(AssertionError) as assertion_info:
-        Coordinator(**expected_coordinator_options)
+        coordinator.Coordinator(**expected_coordinator_options)
     assert str(assertion_info.value) == \
         'End time (2014-12-22T10:56Z) must be greater than the start time (2015-01-01T10:56Z)'

--- a/tests/pyoozie/test_coordinator.py
+++ b/tests/pyoozie/test_coordinator.py
@@ -55,8 +55,9 @@ def test_coordinator_with_controls_and_more(coordinator_xml_with_controls, expec
         }),
         **expected_coordinator_options
     ).xml()
-    assert tests.utils.xml_to_dict_unordered(coordinator_xml_with_controls) == \
-        tests.utils.xml_to_dict_unordered(actual)
+    expected_dict = tests.utils.xml_to_dict_unordered(coordinator_xml_with_controls)
+    actual_dict = tests.utils.xml_to_dict_unordered(actual)
+    assert expected_dict == actual_dict
 
 
 def test_really_long_coordinator_name(expected_coordinator_options):

--- a/tests/pyoozie/test_model.py
+++ b/tests/pyoozie/test_model.py
@@ -2,10 +2,10 @@
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals
 
-from datetime import datetime
-from six import string_types
+import datetime
 import mock
 import pytest
+import six
 
 from pyoozie import exceptions
 from pyoozie import model
@@ -348,7 +348,7 @@ def test_status():
 
 def test_parse_time():
     result = model._parse_time(None, 'Fri, 01 Jan 2016 01:02:03 GMT')
-    assert result == datetime(2016, 1, 1, 1, 2, 3)
+    assert result == datetime.datetime(2016, 1, 1, 1, 2, 3)
 
 
 def test_parse_configuration():
@@ -548,10 +548,10 @@ def test_parse_coordinator(valid_coordinator):
     }
     assert coord.coordJobId == SAMPLE_COORD_ID
     assert coord.coordJobName == 'my-test-coordinator'
-    assert coord.startTime == datetime(2016, 5, 14, 1, 0, 0)
-    assert coord.endTime == datetime(2116, 5, 13, 23, 42, 0)
-    assert coord.lastAction == datetime(2016, 6, 3, 1, 0, 0)
-    assert coord.nextMaterializedTime == datetime(2016, 6, 3, 1, 0, 0)
+    assert coord.startTime == datetime.datetime(2016, 5, 14, 1, 0, 0)
+    assert coord.endTime == datetime.datetime(2116, 5, 13, 23, 42, 0)
+    assert coord.lastAction == datetime.datetime(2016, 6, 3, 1, 0, 0)
+    assert coord.nextMaterializedTime == datetime.datetime(2016, 6, 3, 1, 0, 0)
     assert coord.status == model.CoordinatorStatus.RUNNING
     assert coord._details == {'wat?': 'blarg'}
 
@@ -600,9 +600,9 @@ def test_parse_coordinator_action(valid_coordinator_action):
     assert coord.id == SAMPLE_COORD_ACTION
     assert coord.coordJobId == SAMPLE_COORD_ID
     assert coord.externalId == SAMPLE_WF_ID
-    assert coord.createdTime == datetime(2016, 6, 2, 12, 58, 26)
-    assert coord.lastModifiedTime == datetime(2016, 6, 2, 21, 40, 38)
-    assert coord.nominalTime == datetime(2016, 6, 2, 13, 0, 0)
+    assert coord.createdTime == datetime.datetime(2016, 6, 2, 12, 58, 26)
+    assert coord.lastModifiedTime == datetime.datetime(2016, 6, 2, 21, 40, 38)
+    assert coord.nominalTime == datetime.datetime(2016, 6, 2, 13, 0, 0)
     assert coord.status == model.CoordinatorActionStatus.SUCCEEDED
     assert coord._details == {'wat?': 'blarg'}
 
@@ -666,10 +666,10 @@ def test_parse_workflow(valid_workflow):
     wf = model.Workflow(None, valid_workflow, None)
     assert wf.id == SAMPLE_WF_ID
     assert wf.appName == 'my-test-workflow'
-    assert wf.createdTime == datetime(2016, 6, 2, 13, 16, 46)
-    assert wf.startTime == datetime(2016, 6, 2, 13, 16, 46)
-    assert wf.endTime == datetime(2016, 6, 2, 21, 40, 38)
-    assert wf.lastModTime == datetime(2016, 6, 2, 21, 40, 38)
+    assert wf.createdTime == datetime.datetime(2016, 6, 2, 13, 16, 46)
+    assert wf.startTime == datetime.datetime(2016, 6, 2, 13, 16, 46)
+    assert wf.endTime == datetime.datetime(2016, 6, 2, 21, 40, 38)
+    assert wf.lastModTime == datetime.datetime(2016, 6, 2, 21, 40, 38)
     assert wf.status == model.WorkflowStatus.SUCCEEDED
     assert wf._details == {'wat?': 'blarg'}
 
@@ -716,10 +716,10 @@ def test_parse_workflow_action(valid_workflow_action):
     wf = model.WorkflowAction(None, valid_workflow_action, None)
     assert wf.id == SAMPLE_SUBWF_ACTION
     assert wf.name == 'my-sub-workflow'
-    assert wf.startTime == datetime(2016, 6, 2, 13, 16, 48)
-    assert wf.endTime == datetime(2016, 6, 2, 13, 23, 47)
+    assert wf.startTime == datetime.datetime(2016, 6, 2, 13, 16, 48)
+    assert wf.endTime == datetime.datetime(2016, 6, 2, 13, 23, 47)
     assert wf.status == model.WorkflowActionStatus.OK
-    assert isinstance(wf.conf, string_types)  # Does NOT get parsed
+    assert isinstance(wf.conf, six.string_types)  # Does NOT get parsed
     assert wf._details == {'wat?': 'blarg'}
 
 

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -4,13 +4,12 @@
 from __future__ import unicode_literals, print_function
 
 import decimal
-import pytest
 
-from pyoozie import Parameters, Configuration, Credentials, Shell, SubWorkflow, GlobalConfiguration, Email
-from pyoozie.tags import _validate_id, _validate_name, XMLSerializable, MAX_NAME_LENGTH, MAX_IDENTIFIER_LENGTH, \
-    REGEX_IDENTIFIER
-from six import text_type
-from tests.utils import xml_to_dict_unordered
+import pytest
+import six
+import tests.utils
+
+from pyoozie import tags
 
 
 @pytest.fixture
@@ -66,21 +65,21 @@ def expected_property_values_xml():
 
 def test_validate_id():
     # Simple id
-    _validate_id('ok-id')
+    tags._validate_id('ok-id')
 
     # Max-sized id
-    _validate_id('l' * MAX_IDENTIFIER_LENGTH)
+    tags._validate_id('l' * tags.MAX_IDENTIFIER_LENGTH)
 
 
 def test_validate_id_thats_too_long():
     # Id that is too long
-    very_long_name = 'l' * (MAX_IDENTIFIER_LENGTH + 1)
+    very_long_name = 'l' * (tags.MAX_IDENTIFIER_LENGTH + 1)
     with pytest.raises(AssertionError) as assertion_info:
-        _validate_id(very_long_name)
+        tags._validate_id(very_long_name)
     assert str(assertion_info.value) == (
         "Identifier must be less than {max_length} chars long, '{identifier}' is {length}"
     ).format(
-        max_length=MAX_IDENTIFIER_LENGTH,
+        max_length=tags.MAX_IDENTIFIER_LENGTH,
         identifier=very_long_name,
         length=len(very_long_name)
     )
@@ -89,38 +88,38 @@ def test_validate_id_thats_too_long():
 def test_validate_id_with_illegal_start_char():
     # Id that doesn't satisfy regex because of bad start char
     with pytest.raises(AssertionError) as assertion_info:
-        _validate_id('0-id-starting-with-a-non-alpha-char')
+        tags._validate_id('0-id-starting-with-a-non-alpha-char')
     assert str(assertion_info.value) == (
         "Identifier must match {regex}, '0-id-starting-with-a-non-alpha-char' does not"
-    ).format(regex=REGEX_IDENTIFIER)
+    ).format(regex=tags.REGEX_IDENTIFIER)
 
 
 def test_validate_id_with_illegal_char():
     # Id that doesn't satisfy regex because of illegal char
     with pytest.raises(AssertionError) as assertion_info:
-        _validate_id('id.with.illlegal.chars')
+        tags._validate_id('id.with.illlegal.chars')
     assert str(assertion_info.value) == (
         "Identifier must match {regex}, 'id.with.illlegal.chars' does not"
-    ).format(regex=REGEX_IDENTIFIER)
+    ).format(regex=tags.REGEX_IDENTIFIER)
 
 
 def test_validate_name():
     # Simple name
-    _validate_name('OK name (with punctuation)')
+    tags._validate_name('OK name (with punctuation)')
 
     # Max-sized name
-    _validate_name('l' * MAX_NAME_LENGTH)
+    tags._validate_name('l' * tags.MAX_NAME_LENGTH)
 
 
 def test_validate_name_thats_too_long():
     # Name that is too long
-    very_long_name = 'l' * (MAX_NAME_LENGTH + 1)
+    very_long_name = 'l' * (tags.MAX_NAME_LENGTH + 1)
     with pytest.raises(AssertionError) as assertion_info:
-        _validate_name(very_long_name)
+        tags._validate_name(very_long_name)
     assert str(assertion_info.value) == (
         "Name must be less than {max_length} chars long, '{name}' is {length}"
     ).format(
-        max_length=MAX_NAME_LENGTH,
+        max_length=tags.MAX_NAME_LENGTH,
         name=very_long_name,
         length=len(very_long_name)
     )
@@ -130,14 +129,14 @@ def test_validate_name_with_latin1_char():
     # Name with a latin-1 character
     name_with_non_ascii = 'être'
     with pytest.raises(AssertionError) as assertion_info:
-        _validate_name(name_with_non_ascii)
-    assert text_type(assertion_info.value) == (
+        tags._validate_name(name_with_non_ascii)
+    assert six.text_type(assertion_info.value) == (
         "Name must be comprised of printable ASCII characters, '{name}' is not"
     ).format(name=name_with_non_ascii)
 
 
 def test_xml_serializable():
-    class MyTag(XMLSerializable):
+    class MyTag(tags.XMLSerializable):
 
         def _xml(self, doc, tag, text):
             super(MyTag, self)._xml(doc, tag, text)
@@ -148,28 +147,28 @@ def test_xml_serializable():
 
 
 def test_parameters(expected_property_values, expected_property_values_xml):
-    actual = Parameters(expected_property_values).xml(indent=True)
+    actual = tags.Parameters(expected_property_values).xml(indent=True)
     expected = '<parameters>{xml}</parameters>'.format(xml=expected_property_values_xml)
-    assert xml_to_dict_unordered(expected) == xml_to_dict_unordered(actual)
+    assert tests.utils.xml_to_dict_unordered(expected) == tests.utils.xml_to_dict_unordered(actual)
 
 
 def test_configuration(expected_property_values, expected_property_values_xml):
-    actual = Configuration(expected_property_values).xml(indent=True)
+    actual = tags.Configuration(expected_property_values).xml(indent=True)
     expected = '<configuration>{xml}</configuration>'.format(xml=expected_property_values_xml)
-    assert xml_to_dict_unordered(expected) == xml_to_dict_unordered(actual)
+    assert tests.utils.xml_to_dict_unordered(expected) == tests.utils.xml_to_dict_unordered(actual)
 
 
 def test_credentials(expected_property_values, expected_property_values_xml):
-    actual = Credentials(expected_property_values,
-                         credential_name='my-hcat-creds',
-                         credential_type='hcat').xml(indent=True)
+    actual = tags.Credentials(expected_property_values,
+                              credential_name='my-hcat-creds',
+                              credential_type='hcat').xml(indent=True)
     expected = "<credentials name='my-hcat-creds' type='hcat'>{xml}</credentials>".format(
         xml=expected_property_values_xml)
-    assert xml_to_dict_unordered(expected) == xml_to_dict_unordered(actual)
+    assert tests.utils.xml_to_dict_unordered(expected) == tests.utils.xml_to_dict_unordered(actual)
 
 
 def test_shell():
-    actual = Shell(
+    actual = tags.Shell(
         exec_command='${EXEC}',
         job_tracker='${jobTracker}',
         name_node='${nameNode}',
@@ -187,7 +186,7 @@ def test_shell():
         archives=['/users/blabla/testarchive.jar#testarchive'],
         capture_output=True,
     ).xml(indent=True)
-    assert xml_to_dict_unordered('''
+    assert tests.utils.xml_to_dict_unordered('''
     <shell xmlns="uri:oozie:shell-action:0.3">
         <job-tracker>${jobTracker}</job-tracker>
         <name-node>${nameNode}</name-node>
@@ -206,11 +205,11 @@ def test_shell():
         <env-var>ENVIRONMENT=production</env-var>
         <env-var>RESOURCES=large</env-var>
         <capture-output />
-    </shell>''') == xml_to_dict_unordered(actual)
+    </shell>''') == tests.utils.xml_to_dict_unordered(actual)
 
     # Test using prepares fails
     with pytest.raises(NotImplementedError) as assertion_info:
-        Shell(
+        tags.Shell(
             exec_command='${EXEC}',
             prepares=['anything'],
         ).xml()
@@ -220,30 +219,30 @@ def test_shell():
 def test_subworkflow():
     app_path = '/user/username/workflows/cool-flow'
 
-    actual = SubWorkflow(
+    actual = tags.SubWorkflow(
         app_path=app_path,
         propagate_configuration=False,
         configuration=None,
     ).xml(indent=True)
-    assert xml_to_dict_unordered('''
+    assert tests.utils.xml_to_dict_unordered('''
     <sub-workflow>
         <app-path>/user/username/workflows/cool-flow</app-path>
     </sub-workflow>
-    ''') == xml_to_dict_unordered(actual)
+    ''') == tests.utils.xml_to_dict_unordered(actual)
 
-    actual = SubWorkflow(
+    actual = tags.SubWorkflow(
         app_path=app_path,
         propagate_configuration=True,
         configuration=None,
     ).xml(indent=True)
-    assert xml_to_dict_unordered('''
+    assert tests.utils.xml_to_dict_unordered('''
     <sub-workflow>
         <app-path>/user/username/workflows/cool-flow</app-path>
         <propagate-configuration />
     </sub-workflow>
-    ''') == xml_to_dict_unordered(actual)
+    ''') == tests.utils.xml_to_dict_unordered(actual)
 
-    actual = SubWorkflow(
+    actual = tags.SubWorkflow(
         app_path=app_path,
         propagate_configuration=True,
         configuration={
@@ -251,7 +250,7 @@ def test_subworkflow():
             'name_node': 'hdfs://localhost:50070',
         },
     ).xml(indent=True)
-    assert xml_to_dict_unordered('''
+    assert tests.utils.xml_to_dict_unordered('''
     <sub-workflow>
         <app-path>/user/username/workflows/cool-flow</app-path>
         <propagate-configuration />
@@ -266,7 +265,7 @@ def test_subworkflow():
             </property>
         </configuration>
     </sub-workflow>
-    ''') == xml_to_dict_unordered(actual)
+    ''') == tests.utils.xml_to_dict_unordered(actual)
 
 
 def test_global_configuration():
@@ -274,26 +273,26 @@ def test_global_configuration():
         'mapred.job.queue.name': '${queueName}'
     }
 
-    actual = GlobalConfiguration(
+    actual = tags.GlobalConfiguration(
         job_tracker='a_jobtracker',
         name_node='hdfs://localhost:50070',
         job_xml_files=None,
         configuration=None,
     ).xml(indent=True)
-    assert xml_to_dict_unordered('''
+    assert tests.utils.xml_to_dict_unordered('''
     <global>
         <job-tracker>a_jobtracker</job-tracker>
         <name-node>hdfs://localhost:50070</name-node>
     </global>
-    ''') == xml_to_dict_unordered(actual)
+    ''') == tests.utils.xml_to_dict_unordered(actual)
 
-    actual = GlobalConfiguration(
+    actual = tags.GlobalConfiguration(
         job_tracker='a_jobtracker',
         name_node='hdfs://localhost:50070',
         job_xml_files=['/user/${wf:user()}/job.xml'],
         configuration=configuration,
     ).xml(indent=True)
-    assert xml_to_dict_unordered('''
+    assert tests.utils.xml_to_dict_unordered('''
     <global>
         <job-tracker>a_jobtracker</job-tracker>
         <name-node>hdfs://localhost:50070</name-node>
@@ -305,24 +304,24 @@ def test_global_configuration():
             </property>
         </configuration>
     </global>
-    ''') == xml_to_dict_unordered(actual)
+    ''') == tests.utils.xml_to_dict_unordered(actual)
 
 
 def test_email():
-    actual = Email(
+    actual = tags.Email(
         to='mrt@example.com',
         subject='Chains',
         body='Do you need more?',
     ).xml(indent=True)
-    assert xml_to_dict_unordered('''
+    assert tests.utils.xml_to_dict_unordered('''
     <email xmlns="uri:oozie:email-action:0.2">
         <to>mrt@example.com</to>
         <subject>Chains</subject>
         <body>Do you need more?</body>
     </email>
-    ''') == xml_to_dict_unordered(actual)
+    ''') == tests.utils.xml_to_dict_unordered(actual)
 
-    actual = Email(
+    actual = tags.Email(
         to='mrt@example.com',
         subject='Chains',
         body='Do you need more?',
@@ -331,7 +330,7 @@ def test_email():
         content_type='text/plain',
         attachments='/path/to/attachment/on/hdfs.txt',
     ).xml(indent=True)
-    assert xml_to_dict_unordered('''
+    assert tests.utils.xml_to_dict_unordered('''
     <email xmlns="uri:oozie:email-action:0.2">
         <to>mrt@example.com</to>
         <subject>Chains</subject>
@@ -341,9 +340,9 @@ def test_email():
         <content_type>text/plain</content_type>
         <attachment>/path/to/attachment/on/hdfs.txt</attachment>
     </email>
-    ''') == xml_to_dict_unordered(actual)
+    ''') == tests.utils.xml_to_dict_unordered(actual)
 
-    actual = Email(
+    actual = tags.Email(
         to=['mrt@example.com', 'b.a.baracus@example.com'],
         subject='Chains',
         body='Do you need more?',
@@ -353,7 +352,7 @@ def test_email():
         attachments=['/path/on/hdfs.txt',
                      '/another/path/on/hdfs.txt'],
     ).xml(indent=True)
-    assert xml_to_dict_unordered('''
+    assert tests.utils.xml_to_dict_unordered('''
     <email xmlns="uri:oozie:email-action:0.2">
         <to>b.a.baracus@example.com,mrt@example.com</to>
         <subject>Chains</subject>
@@ -363,4 +362,4 @@ def test_email():
         <content_type>text/plain</content_type>
         <attachment>/another/path/on/hdfs.txt,/path/on/hdfs.txt</attachment>
     </email>
-    ''') == xml_to_dict_unordered(actual)
+    ''') == tests.utils.xml_to_dict_unordered(actual)


### PR DESCRIPTION
This PR:
  - Adds the `shopify_python` linter plugin to pylint
  - Fixes violations of the `import-modules-only` rule
  - Disables the `global-variable` rule for now

Some of the changes to satisfy the `import-modules-only` rule look silly; those situations indicate  areas where we should maybe refactor, e.g. `coordinator.Coordinator` should perhaps be `xml.Coordinator`.