### PR TITLE
Update shopify python to v0.2.0 and fix lint errors

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -51,6 +51,10 @@ disable=missing-docstring,too-few-public-methods,too-many-instance-attributes,to
  protected-access,invalid-name,redefined-outer-name,no-self-use,too-many-public-methods,too-many-lines,
  duplicate-code,fixme
 
+# Increase max except nodes because we often have a pattern of
+# record stats, log, and then re-raise when handling HTTP exceptions
+max-except-nodes=40
+
 
 [REPORTS]
 

--- a/pylintrc
+++ b/pylintrc
@@ -56,7 +56,7 @@ disable=missing-docstring,too-few-public-methods,too-many-instance-attributes,to
 
 # Set the output format. Available formats are text, parseable, colorized, msvs
 # (visual studio) and html
-output-format=text
+output-format=colorized
 
 # Put messages in a separate file for each module / package specified on the
 # command line instead of printing them on stdout. Reports (if any) will be
@@ -77,6 +77,8 @@ evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / stateme
 # Add a comment according to your evaluation note. This is used by the global
 # evaluation report (RP0004).
 comment=no
+
+msg-template="{path}:{line}:{column} {msg_id}({symbol}) {msg}"
 
 
 [VARIABLES]
@@ -163,10 +165,10 @@ const-rgx=(([A-Z_][A-Z0-9_]*)|(__.*__))$
 class-rgx=[A-Z_][a-zA-Z0-9]+$
 
 # Regular expression which should only match correct function names
-function-rgx=[a-z_][a-z0-9_]{2,30}$
+function-rgx=[a-z_][a-z0-9_]{2,90}$
 
 # Regular expression which should only match correct method names
-method-rgx=[a-z_][a-z0-9_]{2,30}$
+method-rgx=[a-z_][a-z0-9_]{2,90}$
 
 # Regular expression which should only match correct instance attribute names
 attr-rgx=[a-z_][a-z0-9_]{2,30}$

--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -3,13 +3,31 @@
 from __future__ import unicode_literals
 
 # pylint: disable=import-modules-only
-from pyoozie.builder import WorkflowBuilder, CoordinatorBuilder
+
+from pyoozie.builder import WorkflowBuilder
+from pyoozie.builder import CoordinatorBuilder
+
 from pyoozie.client import OozieClient
-from pyoozie.coordinator import Coordinator, ExecutionOrder
+
+from pyoozie.coordinator import Coordinator
+from pyoozie.coordinator import ExecutionOrder
 from pyoozie.exceptions import OozieException
-from pyoozie.model import parse_coordinator_id, parse_workflow_id, ArtifactType, \
-    CoordinatorStatus, CoordinatorActionStatus, WorkflowStatus, WorkflowActionStatus
-from pyoozie.tags import Parameters, Configuration, Credentials, Shell, SubWorkflow, GlobalConfiguration, Email
+
+from pyoozie.model import parse_coordinator_id
+from pyoozie.model import parse_workflow_id
+from pyoozie.model import ArtifactType
+from pyoozie.model import CoordinatorStatus
+from pyoozie.model import CoordinatorActionStatus
+from pyoozie.model import WorkflowStatus
+from pyoozie.model import WorkflowActionStatus
+
+from pyoozie.tags import Parameters
+from pyoozie.tags import Configuration
+from pyoozie.tags import Credentials
+from pyoozie.tags import Shell
+from pyoozie.tags import SubWorkflow
+from pyoozie.tags import GlobalConfiguration
+from pyoozie.tags import Email
 
 __version__ = '0.0.0'
 

--- a/setup.py
+++ b/setup.py
@@ -50,11 +50,11 @@ setup(
             'pytest>=2.7',
             'requests-mock',
             'xmltodict',
-            'shopify_python==0.1.2',
+            'shopify_python==0.2.0',
         ],
     },
     dependency_links=[
-        'git+https://github.com/Shopify/shopify_python.git@v0.1.2#egg=shopify_python-0.1.2',
+        'git+https://github.com/Shopify/shopify_python.git@v0.2.0#egg=shopify_python-0.2.0',
     ],
     license="MIT",
     keywords=['oozie'],

--- a/tests/pyoozie/test_builder.py
+++ b/tests/pyoozie/test_builder.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
-from __future__ import unicode_literals, print_function
+from __future__ import unicode_literals
 
 import datetime
 import subprocess
@@ -140,9 +140,9 @@ def test_workflow_builder(tmpdir, workflow_builder):
     assert tests.utils.xml_to_dict_unordered(expected_xml) == tests.utils.xml_to_dict_unordered(actual_xml)
 
     # Does it validate against the workflow XML schema?
+    filename = tmpdir.join("workflow.xml")
+    filename.write_text(actual_xml, encoding='utf8')
     try:
-        filename = tmpdir.join("workflow.xml")
-        filename.write_text(actual_xml, encoding='utf8')
         subprocess.check_output(
             'java -cp lib/oozie-client-4.1.0.jar:lib/commons-cli-1.2.jar '
             'org.apache.oozie.cli.OozieCLI validate {path}'.format(path=str(filename)),

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
-from __future__ import unicode_literals, print_function
+from __future__ import unicode_literals
 
 import decimal
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
-from __future__ import unicode_literals, print_function
+from __future__ import unicode_literals
 
 import xmltodict
 


### PR DESCRIPTION
This PR updates `shopify_python` from 0.1.2 to 0.2.0 and syncs `pylintrc` with `shopify_python` which brings with it a number of new linter rules checks. This PR also fixes lint errors by:
  - Removing multiple imports on a line
  - Moving a lot of code out of `try`'s
  - Increasing the max except block size