### PR TITLE
Make validate_id and validate_name public

### DIFF
--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -11,6 +11,7 @@ from pyoozie.client import OozieClient
 
 from pyoozie.coordinator import Coordinator
 from pyoozie.coordinator import ExecutionOrder
+
 from pyoozie.exceptions import OozieException
 
 from pyoozie.model import parse_coordinator_id
@@ -28,6 +29,8 @@ from pyoozie.tags import Shell
 from pyoozie.tags import SubWorkflow
 from pyoozie.tags import GlobalConfiguration
 from pyoozie.tags import Email
+from pyoozie.tags import validate_xml_name
+from pyoozie.tags import validate_xml_id
 
 __version__ = '0.0.0'
 
@@ -37,6 +40,7 @@ __all__ = (
 
     # tags
     'Configuration', 'Parameters', 'Credentials', 'Shell', 'SubWorkflow', 'GlobalConfiguration', 'Email',
+    'validate_xml_name', 'validate_xml_id',
 
     # builder
     'WorkflowBuilder', 'CoordinatorBuilder',

--- a/pyoozie/builder.py
+++ b/pyoozie/builder.py
@@ -30,7 +30,7 @@ class WorkflowBuilder(object):
 
     def __init__(self, name):
         # Initially, let's just use a static template and only one action payload and one action on error
-        self._name = tags._validate_name(name)
+        self._name = tags.validate_xml_name(name)
         self._action_name = None
         self._action_payload = None
         self._action_error = None
@@ -42,7 +42,7 @@ class WorkflowBuilder(object):
         if any((self._action_name, self._action_payload, self._action_error, self._kill_message)):
             raise NotImplementedError("Can only add one action in this version")
         else:
-            self._action_name = tags._validate_id('action-' + name)
+            self._action_name = tags.validate_xml_id('action-' + name)
             self._action_payload = action
             self._action_error = action_on_error
             self._kill_message = kill_on_error

--- a/pyoozie/coordinator.py
+++ b/pyoozie/coordinator.py
@@ -42,7 +42,7 @@ class Coordinator(tags.XMLSerializable):
             frequency=frequency)
 
         # Coordinator
-        self.name = tags._validate_name(name)
+        self.name = tags.validate_xml_name(name)
         self.frequency = frequency
         self.start = start
         self.end = end

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -13,7 +13,7 @@ COMPILED_REGEX_IDENTIFIER = re.compile(REGEX_IDENTIFIER)
 ALLOWABLE_NAME_CHARS = set(string.ascii_letters + string.punctuation + string.digits + ' ')
 
 
-def _validate_name(name):
+def validate_xml_name(name):
     assert len(name) <= MAX_NAME_LENGTH, \
         "Name must be less than {max_length} chars long, '{name}' is {length}".format(
             max_length=MAX_NAME_LENGTH,
@@ -26,7 +26,7 @@ def _validate_name(name):
     return name
 
 
-def _validate_id(identifier):
+def validate_xml_id(identifier):
     assert len(identifier) <= MAX_IDENTIFIER_LENGTH, \
         "Identifier must be less than {max_length} chars long, '{identifier}' is {length}".format(
             max_length=MAX_IDENTIFIER_LENGTH,
@@ -146,7 +146,7 @@ class Credentials(_PropertyList):
                                    'type': credential_type,
                                },
                                values=values)
-        self.name = _validate_id(credential_name)
+        self.name = validate_xml_id(credential_name)
 
 
 class Shell(XMLSerializable):

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -63,19 +63,19 @@ def expected_property_values_xml():
         </property>'''
 
 
-def test_validate_id():
+def test_validate_xml_id():
     # Simple id
-    tags._validate_id('ok-id')
+    tags.validate_xml_id('ok-id')
 
     # Max-sized id
-    tags._validate_id('l' * tags.MAX_IDENTIFIER_LENGTH)
+    tags.validate_xml_id('l' * tags.MAX_IDENTIFIER_LENGTH)
 
 
-def test_validate_id_thats_too_long():
+def test_validate_xml_id_thats_too_long():
     # Id that is too long
     very_long_name = 'l' * (tags.MAX_IDENTIFIER_LENGTH + 1)
     with pytest.raises(AssertionError) as assertion_info:
-        tags._validate_id(very_long_name)
+        tags.validate_xml_id(very_long_name)
     assert str(assertion_info.value) == (
         "Identifier must be less than {max_length} chars long, '{identifier}' is {length}"
     ).format(
@@ -85,37 +85,37 @@ def test_validate_id_thats_too_long():
     )
 
 
-def test_validate_id_with_illegal_start_char():
+def test_validate_xml_id_with_illegal_start_char():
     # Id that doesn't satisfy regex because of bad start char
     with pytest.raises(AssertionError) as assertion_info:
-        tags._validate_id('0-id-starting-with-a-non-alpha-char')
+        tags.validate_xml_id('0-id-starting-with-a-non-alpha-char')
     assert str(assertion_info.value) == (
         "Identifier must match {regex}, '0-id-starting-with-a-non-alpha-char' does not"
     ).format(regex=tags.REGEX_IDENTIFIER)
 
 
-def test_validate_id_with_illegal_char():
+def test_validate_xml_id_with_illegal_char():
     # Id that doesn't satisfy regex because of illegal char
     with pytest.raises(AssertionError) as assertion_info:
-        tags._validate_id('id.with.illlegal.chars')
+        tags.validate_xml_id('id.with.illlegal.chars')
     assert str(assertion_info.value) == (
         "Identifier must match {regex}, 'id.with.illlegal.chars' does not"
     ).format(regex=tags.REGEX_IDENTIFIER)
 
 
-def test_validate_name():
+def test_validate_xml_name():
     # Simple name
-    tags._validate_name('OK name (with punctuation)')
+    tags.validate_xml_name('OK name (with punctuation)')
 
     # Max-sized name
-    tags._validate_name('l' * tags.MAX_NAME_LENGTH)
+    tags.validate_xml_name('l' * tags.MAX_NAME_LENGTH)
 
 
-def test_validate_name_thats_too_long():
+def test_validate_xml_name_thats_too_long():
     # Name that is too long
     very_long_name = 'l' * (tags.MAX_NAME_LENGTH + 1)
     with pytest.raises(AssertionError) as assertion_info:
-        tags._validate_name(very_long_name)
+        tags.validate_xml_name(very_long_name)
     assert str(assertion_info.value) == (
         "Name must be less than {max_length} chars long, '{name}' is {length}"
     ).format(
@@ -125,11 +125,11 @@ def test_validate_name_thats_too_long():
     )
 
 
-def test_validate_name_with_latin1_char():
+def test_validate_xml_name_with_latin1_char():
     # Name with a latin-1 character
     name_with_non_ascii = 'être'
     with pytest.raises(AssertionError) as assertion_info:
-        tags._validate_name(name_with_non_ascii)
+        tags.validate_xml_name(name_with_non_ascii)
     assert six.text_type(assertion_info.value) == (
         "Name must be comprised of printable ASCII characters, '{name}' is not"
     ).format(name=name_with_non_ascii)


### PR DESCRIPTION
This PR renames and makes public two functions, `validate_xml_name` and `validate_xml_id`. These are useful for API users who are trying to create valid workflow/coordinator names (validated by `validate_xml_name`) or valid action names (validated by `validate_xml_id`).

Fixes https://github.com/Shopify/pyoozie/issues/18.