### PR TITLE
Fix pluralization of credential tag

### DIFF
--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -24,7 +24,7 @@ from pyoozie.model import WorkflowActionStatus
 
 from pyoozie.tags import Parameters
 from pyoozie.tags import Configuration
-from pyoozie.tags import Credentials
+from pyoozie.tags import Credential
 from pyoozie.tags import Shell
 from pyoozie.tags import SubWorkflow
 from pyoozie.tags import GlobalConfiguration
@@ -39,7 +39,7 @@ __all__ = (
     'Coordinator', 'ExecutionOrder',
 
     # tags
-    'Configuration', 'Parameters', 'Credentials', 'Shell', 'SubWorkflow', 'GlobalConfiguration', 'Email',
+    'Configuration', 'Parameters', 'Credential', 'Shell', 'SubWorkflow', 'GlobalConfiguration', 'Email',
     'validate_xml_name', 'validate_xml_id',
 
     # builder

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -118,7 +118,7 @@ class Configuration(_PropertyList):
         _PropertyList.__init__(self, 'configuration', values=values)
 
 
-class Credentials(_PropertyList):
+class Credential(_PropertyList):
     """HCatalog, Hive Metastore, HBase, or Hive Server 2 action credentials.
 
     Generates XML of the form:
@@ -140,7 +140,7 @@ class Credentials(_PropertyList):
     """
 
     def __init__(self, values, credential_name, credential_type):
-        _PropertyList.__init__(self, 'credentials',
+        _PropertyList.__init__(self, 'credential',
                                attributes={
                                    'name': credential_name,
                                    'type': credential_type,

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -158,11 +158,11 @@ def test_configuration(expected_property_values, expected_property_values_xml):
     assert tests.utils.xml_to_dict_unordered(expected) == tests.utils.xml_to_dict_unordered(actual)
 
 
-def test_credentials(expected_property_values, expected_property_values_xml):
-    actual = tags.Credentials(expected_property_values,
-                              credential_name='my-hcat-creds',
-                              credential_type='hcat').xml(indent=True)
-    expected = "<credentials name='my-hcat-creds' type='hcat'>{xml}</credentials>".format(
+def test_credential(expected_property_values, expected_property_values_xml):
+    actual = tags.Credential(expected_property_values,
+                             credential_name='my-hcat-creds',
+                             credential_type='hcat').xml(indent=True)
+    expected = "<credential name='my-hcat-creds' type='hcat'>{xml}</credential>".format(
         xml=expected_property_values_xml)
     assert tests.utils.xml_to_dict_unordered(expected) == tests.utils.xml_to_dict_unordered(actual)
 


### PR DESCRIPTION
This PR changes how the `credential` tag is implemented to remove its pluralization because [`oozie-workflow-0.5.xsd`](https://github.com/apache/oozie/blob/master/client/src/main/resources/oozie-workflow-0.5.xsd) indicates that this tag shouldn't be pluralized:

```
    <xs:complexType name="CREDENTIAL">
        <xs:sequence  minOccurs="0" maxOccurs="unbounded" >
                 <xs:element name="property" minOccurs="1" maxOccurs="unbounded">
                    <xs:complexType>
                       <xs:sequence>
                            <xs:element name="name" minOccurs="1" maxOccurs="1" type="xs:string"/>
                            <xs:element name="value" minOccurs="1" maxOccurs="1" type="xs:string"/>
                            <xs:element name="description" minOccurs="0" maxOccurs="1" type="xs:string"/>
                       </xs:sequence>
                    </xs:complexType>
                 </xs:element>
        </xs:sequence>
        <xs:attribute name="name" type="xs:string" use="required"/>
        <xs:attribute name="type" type="xs:string" use="required"/>
    </xs:complexType>
```