### PR TITLE
Add mypy and pep8 linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 python_files := find . -path '*/.*' -prune -o -name '*.py' -print0
+python_version_full := $(wordlist 2,4,$(subst ., ,$(shell python --version 2>&1)))
+python_version_major := $(word 1,${python_version_full})
 
 all: install test lint
 
@@ -27,7 +29,11 @@ autopep8:
 
 lint:
 		@echo 'Linting...'
-		@pylint --rcfile=pylintrc pyoozie tests
-		@flake8
+		@pylint --rcfile=pylintrc setup.py pyoozie tests
+		@if [ "$(python_version_major)" = "3" ]; then \
+			echo 'Checking type annotations...'; \
+			mypy --py2 pyoozie tests --ignore-missing-imports; \
+		fi
+		@pep8
 
 autolint: autopep8 lint

--- a/pyoozie/model.py
+++ b/pyoozie/model.py
@@ -7,6 +7,7 @@ import datetime
 import re
 
 import enum
+import typing  # pylint: disable=unused-import
 import untangle
 
 from pyoozie import exceptions
@@ -244,9 +245,9 @@ class WorkflowActionStatus(_StatusEnum):
 
 class _OozieArtifact(object):
 
-    REQUIRED_KEYS = {}
+    REQUIRED_KEYS = {}  # type: typing.Dict[unicode, typing.Callable]
 
-    SUPPORTED_KEYS = {'toString': None}
+    SUPPORTED_KEYS = {'toString': None}  # type: typing.Dict[unicode, typing.Callable]
 
     def __init__(self, oozie_client, details, parent=None):
         self._client = oozie_client

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,10 +1,5 @@
-[flake8]
-# Ignoring:
-# D100 Missing docstring in public module
-# D101 Missing docstring in public class
-# D102 Missing docstring in public method
-# D103 Missing docstring in public function
-# D104 Missing docstring in public package
-# D105 Missing docstring in magic method
-ignore=D100,D101,D102,D103,D104,D105
+[pep8]
+max-line-length = 120
+
+[autopep8]
 max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -5,26 +5,24 @@ import re
 
 
 try:
-    from setuptools import setup
-except:
-    from distutils.core import setup
+    import setuptools as setuplib
+except ImportError:
+    import distutils.core as setuplib
 
 
-with open('README.md') as fh:
-    long_description = fh.read()
+def get_version():
+    version = None
+    with open('pyoozie/__init__.py', 'r') as fdesc:
+        version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fdesc.read(), re.MULTILINE).group(1)
+    if not version:
+        raise RuntimeError('Cannot find version information')
+    return version
 
-with open('pyoozie/__init__.py', 'r') as fd:
-    version = re.search(r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]',
-                        fd.read(), re.MULTILINE).group(1)
 
-if not version:
-    raise RuntimeError('Cannot find version information')
-
-setup(
+setuplib.setup(
     name='pyoozie',
-    version=version,
+    version=get_version(),
     description='A Python client for querying and scheduling with Oozie',
-    long_description=long_description,
     author='Shopify Data Acceleration',
     author_email='data-acceleration@shopify.com',
     url='https://github.com/Shopify/pyoozie',
@@ -33,6 +31,7 @@ setup(
         'enum34>=0.9.23',
         'requests>=2.12.3',
         'six>=1.10.0',
+        'typing',
         'untangle>=1.1.0',
         'yattag>=1.7.2',
     ],
@@ -44,13 +43,15 @@ setup(
             'autopep8',
             'flake8',
             'mock',
+            'mypy; python_version >= "3.3"',
+            'pep8',
             'pylint',
             'pytest-cov',
             'pytest-randomly',
             'pytest>=2.7',
             'requests-mock',
-            'xmltodict',
             'shopify_python==0.2.0',
+            'xmltodict',
         ],
     },
     dependency_links=[


### PR DESCRIPTION
This PR syncs up the `Makefile` with [shopify_python](https://github.com/Shopify/shopify_python) by adding the mypy and pep8 linters (and linting `setup.py`).