### PR TITLE
[WIP] Add prototype scoping interface to defining a workflow

### DIFF
--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals
 import abc
+import copy
 import datetime
 import re
 import string  # pylint: disable=deprecated-module
@@ -406,5 +407,44 @@ class CoordinatorApp(XMLSerializable):
                         text(self.workflow_app_path)
                     if self.workflow_configuration:
                         self.workflow_configuration._xml(doc, tag, text)
+
+        return doc
+
+
+class WorkflowApp(XMLSerializable):
+    """Workflow 0.5"""
+
+    def __init__(self, name, actions, parameters=None, configuration=None, credentials=None, job_tracker=None,
+                 name_node=None, job_xml_files=None, default_retry_max=None, default_retry_interval=None,
+                 default_retry_policy=None):
+        XMLSerializable.__init__(self, 'workflow-app')
+        self.name = validate_xml_name(name)
+        self.actions = copy.deepcopy(actions)
+
+        self.parameters = Parameters(parameters)
+        self.global_configuration = GlobalConfiguration(
+            job_tracker=job_tracker,
+            name_node=name_node,
+            job_xml_files=job_xml_files,
+            configuration=configuration
+        )
+        self.credentials = [Credential(**credential) for credential in credentials] if credentials else None
+
+        self.default_retry_max = default_retry_max
+        self.default_retry_interval = default_retry_interval
+        self.default_retry_policy = default_retry_policy
+
+    def _xml(self, doc, tag, text):
+        with tag(self.xml_tag, name=self.name, xmlns="uri:oozie:workflow:0.5"):
+
+            # Preamble
+            if self.parameters:
+                self.parameters._xml(doc, tag, text)
+            if self.global_configuration:
+                self.global_configuration._xml(doc, tag, text)
+            if self.credentials:
+                with tag('credentials'):
+                    for credential in self.credentials:
+                        credential._xml(doc, tag, text)
 
         return doc

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -447,4 +447,6 @@ class WorkflowApp(XMLSerializable):
                     for credential in self.credentials:
                         credential._xml(doc, tag, text)
 
+            # TODO add actions
+
         return doc

--- a/pyoozie/workflow.py
+++ b/pyoozie/workflow.py
@@ -1,43 +1,81 @@
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
+import abc
+import copy
 import typing  # pylint: disable=unused-import
 
 from pyoozie import tags  # pylint: disable=unused-import
 
 
-class AbstractAction(object):
-    pass
+# TODO auto-generate Oozie compatible ids
+
+
+class AbstractIdentifiedNode(object):
+    """Workflow tags representing nodes in a workflow's execution, e.g. Kill, and Action"""
+
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, identifier):
+        # type: (AbstractAction) -> None
+        self.__identifier = identifier
+
+    def identifier(self):
+        return self.__identifier
+
+
+class AbstractAction(AbstractIdentifiedNode):
+    """Parent class of both Action and action collections"""
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, identifier=None, on_error=None):
+        # type: (str, AbstractIdentifiedNode) -> None
+        super(AbstractAction, self).__init__(identifier=identifier or 'auto-generated-id-here')
+        self.__on_error = copy.deepcopy(on_error)
+
+    def on_error(self):
+        return self.__on_error
 
 
 class Action(AbstractAction):
     """Concrete action to execute (takes an action tag, e.g. pyoozie.Shell, pyoozie.Email. etc.)"""
 
     def __init__(self, action_tag, on_error=None):
-        # type: (tags.Shell, AbstractAction) -> None
-        self.__action_tag = action_tag
-        self.__on_error = on_error
+        # type: (typing.Union[tags.Email, tags.Shell, tags.SubWorkflow], AbstractIdentifiedNode) -> None
+        super(Action, self).__init__(identifier='auto-generated', on_error=on_error)
+        self.action_tag = action_tag
 
 
-class Sequence(AbstractAction):
-    """Set of actions to execute sequentially (implemented by chaining actions and 'OK' transitions)"""
+class Serial(AbstractAction):
+    """Collection of actions to execute sequentially (implemented by chaining actions and 'OK' transitions)"""
 
     def __init__(self, *actions, **kwargs):
-        # type: (typing.Tuple[AbstractAction, ...], typing.Dict[str, AbstractAction]) -> None
-        self.__on_error = kwargs.get('on_error')
-        self.__actions = actions
+        # type: (typing.Tuple[AbstractAction, ...], typing.Dict[str, AbstractIdentifiedNode]) -> None
+        super(Serial, self).__init__(identifier='auto-generated', on_error=kwargs.get('on_error'))
+        self.actions = copy.deepcopy(actions)
 
 
-class Parallelization(AbstractAction):
+class Parallel(AbstractAction):
     """Set of actions to execute in parallel (implemented as fork/join tag pair)"""
 
     def __init__(self, *actions, **kwargs):
-        # type: (typing.Tuple[AbstractAction, ...], typing.Dict[str, AbstractAction]) -> None
-        self.__on_error = kwargs.get('on_error')
-        self.__actions = set(actions)
+        # type: (typing.Tuple[AbstractAction, ...], typing.Dict[str, AbstractIdentifiedNode]) -> None
+        super(Parallel, self).__init__(identifier='auto-generated', on_error=kwargs.get('on_error'))
+        self.actions = set(copy.deepcopy(actions))
 
 
-class Kill(AbstractAction):
+class Switch(AbstractAction):
+    """Set of JSP Expression Language case statements and actions to follow as a result"""
+
+    def __init__(self, cases, default):
+        # type: Dict[str, AbstractIdentifiedNode], AbstractIdentifiedNode) -> None
+        super(Switch, self).__init__(identifier='auto-generated', on_error=None)
+        self.cases = set(copy.deepcopy(cases))
+        self.default = copy.deepcopy(default)
+
+
+class Kill(AbstractIdentifiedNode):
     """Stop execution immediately"""
 
     def __init__(self, message):
+        super(Kill, self).__init__(identifier='auto-generated')
         self.__message = message

--- a/pyoozie/workflow.py
+++ b/pyoozie/workflow.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2017 "Shopify inc." All rights reserved.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
+import typing  # pylint: disable=unused-import
+
+
+class AbstractAction(object):
+    pass
+
+
+class Action(AbstractAction):
+    """Concrete action to execute (takes an action tag, e.g. pyoozie.Shell, pyoozie.Email. etc.)"""
+
+    def __init__(self, action_tag, on_error=None):
+        # type: (tags.ActionTag, AbstractAction) -> None
+        self.__action_tag = action_tag
+        self.__on_error = on_error
+
+
+class Sequence(AbstractAction):
+    """Set of actions to execute sequentially (implemented by chaining actions and 'OK' transitions)"""
+
+    def __init__(self, *actions, on_error=None):
+        # TODO type: (typing.Sequence[AbstractAction], AbstractAction) -> None
+        self.__on_error = on_error
+        self.__actions = actions
+
+
+class Parallelization(AbstractAction):
+    """Set of actions to execute in parallel (implemented as fork/join tag pair)"""
+
+    def __init__(self, *actions, on_error=None):
+        # TODO type: (typing.Iterable[AbstractAction], AbstractAction) -> None
+        self.__on_error = on_error
+        self.__actions = set()
+        for action in actions:
+            self.__actions.add(action)
+
+
+class Kill(AbstractAction):
+    """Stop execution immediately"""
+
+    def __init__(self, message):
+        self.__message = message

--- a/pyoozie/workflow.py
+++ b/pyoozie/workflow.py
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 import typing  # pylint: disable=unused-import
 
+from pyoozie import tags  # pylint: disable=unused-import
+
 
 class AbstractAction(object):
     pass
@@ -11,7 +13,7 @@ class Action(AbstractAction):
     """Concrete action to execute (takes an action tag, e.g. pyoozie.Shell, pyoozie.Email. etc.)"""
 
     def __init__(self, action_tag, on_error=None):
-        # type: (tags.ActionTag, AbstractAction) -> None
+        # type: (tags.Shell, AbstractAction) -> None
         self.__action_tag = action_tag
         self.__on_error = on_error
 
@@ -19,21 +21,19 @@ class Action(AbstractAction):
 class Sequence(AbstractAction):
     """Set of actions to execute sequentially (implemented by chaining actions and 'OK' transitions)"""
 
-    def __init__(self, *actions, on_error=None):
-        # TODO type: (typing.Sequence[AbstractAction], AbstractAction) -> None
-        self.__on_error = on_error
+    def __init__(self, *actions, **kwargs):
+        # type: (typing.Tuple[AbstractAction, ...], typing.Dict[str, AbstractAction]) -> None
+        self.__on_error = kwargs.get('on_error')
         self.__actions = actions
 
 
 class Parallelization(AbstractAction):
     """Set of actions to execute in parallel (implemented as fork/join tag pair)"""
 
-    def __init__(self, *actions, on_error=None):
-        # TODO type: (typing.Iterable[AbstractAction], AbstractAction) -> None
-        self.__on_error = on_error
-        self.__actions = set()
-        for action in actions:
-            self.__actions.add(action)
+    def __init__(self, *actions, **kwargs):
+        # type: (typing.Tuple[AbstractAction, ...], typing.Dict[str, AbstractAction]) -> None
+        self.__on_error = kwargs.get('on_error')
+        self.__actions = set(actions)
 
 
 class Kill(AbstractAction):

--- a/pyoozie/xml.py
+++ b/pyoozie/xml.py
@@ -29,59 +29,15 @@ def _coordinator_submission_xml(username, coord_xml_path, configuration=None, in
 
 class WorkflowBuilder(object):
 
-    def __init__(self, name):
-        warnings.warn("WorkflowBuilder will be replaced in the future with a different API to construct workflows",
-                      PendingDeprecationWarning)
+    def __init__(self, name, parameters=None, configuration=None, credentials=None, job_tracker=None,
+                 name_node=None, job_xml_files=None, default_retry_max=None, default_retry_interval=None,
+                 default_retry_policy=None, actions=None):
+        # pylint: disable=unused-argument
+        self.__name = tags.validate_xml_name(name)
+        self.__actions = actions
 
-        # Initially, let's just use a static template and only one action payload and one action on error
-        self._name = tags.validate_xml_name(name)
-        self._action_name = None
-        self._action_payload = None
-        self._action_error = None
-        self._kill_message = None
-
-    def add_action(self, name, action, action_on_error, kill_on_error='${wf:lastErrorNode()} - ${wf:id()}'):
-        # Today you can't rename your action and you can only have one, but in the future you can add multiple
-        # named actions
-        if any((self._action_name, self._action_payload, self._action_error, self._kill_message)):
-            raise NotImplementedError("Can only add one action in this version")
-        else:
-            self._action_name = tags.validate_xml_id('action-' + name)
-            self._action_payload = action
-            self._action_error = action_on_error
-            self._kill_message = kill_on_error
-
-        return self
-
-    def build(self, indent=False):
-        def format_xml(xml):
-            xml = xml.replace("<?xml version='1.0' encoding='UTF-8'?>", '')
-            return '\n'.join([(' ' * 8) + line for line in xml.strip().split('\n')])
-        return '''
-<?xml version="1.0" encoding="UTF-8"?>
-<workflow-app xmlns="uri:oozie:workflow:0.5"
-              name="{name}">
-    <start to="{action_name}" />
-    <action name="{action_name}">
-{action_payload_xml}
-        <ok to="end" />
-        <error to="action-error" />
-    </action>
-    <action name="action-error">
-{action_error_xml}
-        <ok to="kill" />
-        <error to="kill" />
-    </action>
-    <kill name="kill">
-        <message>{kill_message}</message>
-    </kill>
-    <end name="end" />
-</workflow-app>
-'''.format(action_payload_xml=format_xml(self._action_payload.xml(indent=indent)),
-           action_error_xml=format_xml(self._action_error.xml(indent=indent)),
-           kill_message=self._kill_message,
-           action_name=self._action_name,
-           name=self._name).strip()
+    def build(self):
+        raise NotImplementedError()
 
 
 class CoordinatorBuilder(object):

--- a/pyoozie/xml.py
+++ b/pyoozie/xml.py
@@ -2,8 +2,6 @@
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals
 
-import warnings
-
 from pyoozie import tags
 
 
@@ -25,44 +23,3 @@ def _coordinator_submission_xml(username, coord_xml_path, configuration=None, in
         'oozie.coord.application.path': coord_xml_path,
     })
     return submission.xml(indent)
-
-
-class WorkflowBuilder(object):
-
-    def __init__(self, name, parameters=None, configuration=None, credentials=None, job_tracker=None,
-                 name_node=None, job_xml_files=None, default_retry_max=None, default_retry_interval=None,
-                 default_retry_policy=None, actions=None):
-        # pylint: disable=unused-argument
-        self.__name = tags.validate_xml_name(name)
-        self.__actions = actions
-
-    def build(self):
-        raise NotImplementedError()
-
-
-class CoordinatorBuilder(object):
-
-    def __init__(self, name, workflow_xml_path, frequency_in_minutes, start, end=None, timezone=None,
-                 workflow_configuration=None, timeout_in_minutes=None, concurrency=None, execution_order=None,
-                 throttle=None, parameters=None):
-        warnings.warn(
-            "CoordinatorBuilder is deprecated in favour of pyoozie.CoordinatorApp and will soon be removed",
-            DeprecationWarning
-        )
-        self._coordinator = tags.CoordinatorApp(
-            name=name,
-            workflow_app_path=workflow_xml_path,
-            frequency=frequency_in_minutes,
-            start=start,
-            end=end,
-            timezone=timezone,
-            workflow_configuration=workflow_configuration,
-            timeout=timeout_in_minutes,
-            concurrency=concurrency,
-            execution_order=execution_order,
-            throttle=throttle,
-            parameters=parameters,
-        )
-
-    def build(self, indent=False):
-        return self._coordinator.xml(indent)

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -470,4 +470,4 @@ def test_workflow_app():
             on_error=workflow.Kill(message='Workflow failed')
         ),
     )
-    assert workflow_builder.xml(indent=True)
+    assert workflow_app.xml(indent=True)

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -11,7 +11,6 @@ import six
 import tests.utils
 
 from pyoozie import tags
-from pyoozie import builder
 from pyoozie import workflow
 
 
@@ -444,8 +443,7 @@ def test_coordinator_end_before_start(expected_coordinator_options):
 
 @pytest.mark.xfail(raises=NotImplementedError)
 def test_workflow_app():
-
-    workflow_builder = builder.WorkflowBuilder(
+    workflow_app = tags.WorkflowApp(
         name='descriptive-name',
         actions=workflow.Serial(
             workflow.Action(tags.Shell(exec_command='echo', arguments=("'A'",))),
@@ -472,4 +470,4 @@ def test_workflow_app():
             on_error=workflow.Kill(message='Workflow failed')
         ),
     )
-    assert workflow_builder.build()
+    assert workflow_builder.xml(indent=True)

--- a/tests/pyoozie/test_xml.py
+++ b/tests/pyoozie/test_xml.py
@@ -3,13 +3,13 @@
 from __future__ import unicode_literals
 
 import datetime
-import subprocess
 
 import pytest
 import tests.utils
 
 from pyoozie import xml
 from pyoozie import tags
+from pyoozie import workflow
 
 
 @pytest.fixture
@@ -25,18 +25,6 @@ def coord_app_path():
 @pytest.fixture
 def username():
     return 'test'
-
-
-@pytest.fixture
-def workflow_builder():
-    return xml.WorkflowBuilder(
-        name='descriptive-name'
-    ).add_action(
-        name='payload',
-        action=tags.Shell(exec_command='echo "test"'),
-        action_on_error=tags.Email(to='person@example.com', subject='Error', body='A bad thing happened'),
-        kill_on_error='Failure message',
-    )
 
 
 def test_workflow_submission_xml(username, workflow_app_path):
@@ -130,82 +118,30 @@ def test_coordinator_submission_xml_with_configuration(username, coord_app_path)
     </configuration>''') == tests.utils.xml_to_dict_unordered(actual)
 
 
-def test_workflow_builder(tmpdir, workflow_builder):
-    with open('tests/data/workflow.xml', 'r') as fh:
-        expected_xml = fh.read()
+@pytest.mark.xfail(raises=NotImplementedError)
+def test_workflow_builder():
 
-    # Is this XML expected
-    actual_xml = workflow_builder.build()
-    assert tests.utils.xml_to_dict_unordered(expected_xml) == tests.utils.xml_to_dict_unordered(actual_xml)
-
-    # Does it validate against the workflow XML schema?
-    filename = tmpdir.join("workflow.xml")
-    filename.write_text(actual_xml, encoding='utf8')
-    try:
-        subprocess.check_output(
-            'java -cp lib/oozie-client-4.1.0.jar:lib/commons-cli-1.2.jar '
-            'org.apache.oozie.cli.OozieCLI validate {path}'.format(path=str(filename)),
-            stderr=subprocess.STDOUT,
-            shell=True
-        )
-    except subprocess.CalledProcessError as e:
-        raise AssertionError('An XML validation error\n\n{error}\n\noccurred while parsing:\n\n{xml}'.format(
-            error=e.output.decode('utf8').strip(),
-            xml=actual_xml,
-        ))
-
-
-def test_builder_raises_on_bad_workflow_name():
-    # Does it throw an exception on a bad workflow name?
-    with pytest.raises(AssertionError) as assertion_info:
-        xml.WorkflowBuilder(
-            name='l' * (tags.MAX_NAME_LENGTH + 1)
-        ).add_action(
-            name='payload',
-            action=tags.Shell(exec_command='echo "test"'),
-            action_on_error=tags.Email(to='person@example.com', subject='Error', body='A bad thing happened'),
-            kill_on_error='Failure message',
-        )
-    assert "Name must be less than " in str(assertion_info.value)
-
-
-def test_builder_raises_on_bad_action_name():
-    # Does it throw an exception on a bad action name?
-    with pytest.raises(AssertionError) as assertion_info:
-        xml.WorkflowBuilder(
-            name='descriptive-name'
-        ).add_action(
-            name='Action name with invalid characters',
-            action=tags.Shell(exec_command='echo "test"'),
-            action_on_error=tags.Email(to='person@example.com', subject='Error', body='A bad thing happened'),
-            kill_on_error='Failure message',
-        )
-    assert "Identifier must match " in str(assertion_info.value) and \
-        "Action name with invalid characters" in str(assertion_info.value)
-
-    # Does it throw an exception on an action name that's too long?
-    with pytest.raises(AssertionError) as assertion_info:
-        xml.WorkflowBuilder(
-            name='descriptive-name'
-        ).add_action(
-            name='l' * (tags.MAX_IDENTIFIER_LENGTH + 1),
-            action=tags.Shell(exec_command='echo "test"'),
-            action_on_error=tags.Email(to='person@example.com', subject='Error', body='A bad thing happened'),
-            kill_on_error='Failure message',
-        )
-    assert "Identifier must be less than " in str(assertion_info.value)
-
-
-def test_builder_raises_on_multiple_actions(workflow_builder):
-    # Does it raise an exception when you try to add multiple actions?
-    with pytest.raises(NotImplementedError) as assertion_info:
-        workflow_builder.add_action(
-            name='payload',
-            action=tags.Shell(exec_command='echo "test"'),
-            action_on_error=tags.Email(to='person@example.com', subject='Error', body='A bad thing happened'),
-            kill_on_error='Failure message',
-        )
-    assert str(assertion_info.value) == 'Can only add one action in this version'
+    workflow_builder = builder.WorkflowBuilder(
+        name='descriptive-name',
+        actions=workflow.Sequence(
+            workflow.Action(tags.Shell(exec_command='echo', arguments=("'A'",))),
+            workflow.Parallelization(
+                workflow.Sequence(
+                    workflow.Action(
+                        tags.Shell(exec_command='echo', arguments=("'B'",)),
+                        on_error=tags.Shell(exec_command='echo', arguments=("'Notify B failed'",)),
+                    )
+                ),
+                workflow.Sequence(
+                    workflow.Action(tags.Shell(exec_command='echo', arguments=("'C'",))),
+                    workflow.Action(tags.Shell(exec_command='echo', arguments=("'D'",))),
+                ),
+                on_error=workflow.Action(tags.Shell(exec_command='echo', arguments=("'A parallel action failed'",))),
+            ),
+            on_error=workflow.Kill('Flow failed')
+        ),
+    )
+    assert workflow_builder.build()
 
 
 def test_coordinator_builder(coordinator_xml_with_controls, workflow_app_path):

--- a/tests/pyoozie/test_xml.py
+++ b/tests/pyoozie/test_xml.py
@@ -115,29 +115,3 @@ def test_coordinator_submission_xml_with_configuration(username, coord_app_path)
             <value>test</value>
         </property>
     </configuration>''') == tests.utils.xml_to_dict_unordered(actual)
-
-
-def test_coordinator_builder(coordinator_xml_with_controls, workflow_app_path):
-
-    coord_builder = xml.CoordinatorBuilder(
-        name='coordinator-name',
-        workflow_xml_path=workflow_app_path,
-        frequency_in_minutes=24 * 60,  # In minutes
-        start=datetime.datetime(2015, 1, 1, 10, 56),
-        end=datetime.datetime(2115, 1, 1, 10, 56),
-        concurrency=1,
-        throttle='${throttle}',
-        timeout_in_minutes=10,
-        execution_order=tags.EXEC_LAST_ONLY,
-        parameters={
-            'throttle': 1,
-        },
-        workflow_configuration={
-            'mapred.job.queue.name': 'production',
-        })
-
-    # Can it XML?
-    expected_xml = coord_builder.build()
-    actual_dict = tests.utils.xml_to_dict_unordered(coordinator_xml_with_controls)
-    expected_dict = tests.utils.xml_to_dict_unordered(expected_xml)
-    assert actual_dict == expected_dict

--- a/tests/pyoozie/test_xml.py
+++ b/tests/pyoozie/test_xml.py
@@ -9,7 +9,6 @@ import tests.utils
 
 from pyoozie import xml
 from pyoozie import tags
-from pyoozie import workflow
 
 
 @pytest.fixture
@@ -116,32 +115,6 @@ def test_coordinator_submission_xml_with_configuration(username, coord_app_path)
             <value>test</value>
         </property>
     </configuration>''') == tests.utils.xml_to_dict_unordered(actual)
-
-
-@pytest.mark.xfail(raises=NotImplementedError)
-def test_workflow_builder():
-
-    workflow_builder = builder.WorkflowBuilder(
-        name='descriptive-name',
-        actions=workflow.Sequence(
-            workflow.Action(tags.Shell(exec_command='echo', arguments=("'A'",))),
-            workflow.Parallelization(
-                workflow.Sequence(
-                    workflow.Action(
-                        tags.Shell(exec_command='echo', arguments=("'B'",)),
-                        on_error=tags.Shell(exec_command='echo', arguments=("'Notify B failed'",)),
-                    )
-                ),
-                workflow.Sequence(
-                    workflow.Action(tags.Shell(exec_command='echo', arguments=("'C'",))),
-                    workflow.Action(tags.Shell(exec_command='echo', arguments=("'D'",))),
-                ),
-                on_error=workflow.Action(tags.Shell(exec_command='echo', arguments=("'A parallel action failed'",))),
-            ),
-            on_error=workflow.Kill('Flow failed')
-        ),
-    )
-    assert workflow_builder.build()
 
 
 def test_coordinator_builder(coordinator_xml_with_controls, workflow_app_path):


### PR DESCRIPTION
This is a prototype interface that would allow one to define the following fork/join graph and (with inherent fork/joins) with the ability to specify actions to perform on error at each "scope" (i.e. wrapped action, sequence of actions, or fork/join of actions).

The following graph doesn't show error handling nodes, but when you don't define error handling for a scope then we exit the current scope and execute the parent scope's error handling (much like exception handling works).

```
   S
   |
   A
   |
 Fork
 /   \
B     C
|     |
|     D
 \   /
 Join
   |
   E
```

Not intended to be merged.