### PR TITLE
Add types to pyoozie.tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,13 +27,17 @@ autopep8:
 		@echo 'Auto Formatting...'
 		@$(python_files) | xargs -0 autopep8 --max-line-length 120 --jobs 0 --in-place --aggressive
 
-lint:
-		@echo 'Linting...'
-		@pylint --rcfile=pylintrc setup.py pyoozie tests
+type:
 		@if [ "$(python_version_major)" = "3" ]; then \
 			echo 'Checking type annotations...'; \
 			mypy --py2 pyoozie tests --ignore-missing-imports; \
 		fi
+
+sourcelint:
+		@echo 'Linting...'
+		@pylint --rcfile=pylintrc setup.py pyoozie tests
 		@pep8
+
+lint: sourcelint type
 
 autolint: autopep8 lint

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -19,8 +19,8 @@ COMPILED_REGEX_IDENTIFIER = re.compile(REGEX_IDENTIFIER)
 ALLOWABLE_NAME_CHARS = set(string.ascii_letters + string.punctuation + string.digits + ' ')
 ONE_HUNDRED_YEARS = 100 * 365.24
 
-PropertyValuesType = typing.Optional[typing.Dict[typing.Text, typing.Any]]
-JobXmlFilesType = typing.Optional[typing.Iterable[typing.Text]]
+PropertyValuesType = typing.Dict[typing.Text, typing.Any]
+JobXmlFilesType = typing.Iterable[typing.Text]
 
 
 class ExecutionOrder(enum.Enum):
@@ -116,7 +116,7 @@ class _PropertyList(XMLSerializable, dict):
             self,
             xml_tag,          # type: typing.Text
             attributes=None,  # type: typing.Optional[typing.Dict[typing.Text, typing.Text]]
-            values=None       # type: PropertyValuesType
+            values=None       # type: typing.Optional[PropertyValuesType]
     ):
         # type: (...) -> None
         super(_PropertyList, self).__init__(xml_tag=xml_tag)
@@ -147,7 +147,7 @@ class Parameters(_PropertyList):
     """
 
     def __init__(self, values=None):
-        # type: (PropertyValuesType) -> None
+        # type: (typing.Optional[PropertyValuesType]) -> None
         super(Parameters, self).__init__(xml_tag='parameters', values=values)
 
 
@@ -155,7 +155,7 @@ class Configuration(_PropertyList):
     """Coordinator job submission, workflow, workflow action configuration XML."""
 
     def __init__(self, values=None):
-        # type: (PropertyValuesType) -> None
+        # type: (typing.Optional[PropertyValuesType]) -> None
         super(Configuration, self).__init__(xml_tag='configuration', values=values)
 
 
@@ -207,10 +207,10 @@ class Shell(XMLSerializable):
             job_tracker=None,     # type: typing.Optional[typing.Text]
             name_node=None,       # type: typing.Optional[typing.Text]
             prepare=None,         # type: typing.Optional[typing.Sequence]
-            job_xml_files=None,   # type: JobXmlFilesType
-            configuration=None,   # type: PropertyValuesType
+            job_xml_files=None,   # type: typing.Optional[JobXmlFilesType]
+            configuration=None,   # type: typing.Optional[PropertyValuesType]
             arguments=None,       # type: typing.Optional[typing.Iterable[typing.Text]]
-            env_vars=None,        # type: PropertyValuesType
+            env_vars=None,        # type: typing.Optional[PropertyValuesType]
             files=None,           # type: typing.Optional[typing.Iterable[typing.Text]]
             archives=None,        # type: typing.Optional[typing.Iterable[typing.Text]]
             capture_output=False  # type: bool
@@ -286,7 +286,7 @@ class SubWorkflow(XMLSerializable):
             self,
             app_path,                      # type: str
             propagate_configuration=True,  # type: bool
-            configuration=None             # type: PropertyValuesType
+            configuration=None             # type: typing.Optional[PropertyValuesType]
     ):
         # type: (...) -> None
         super(SubWorkflow, self).__init__(xml_tag='sub-workflow')
@@ -323,8 +323,8 @@ class GlobalConfiguration(XMLSerializable):
             self,
             job_tracker=None,    # type: typing.Optional[typing.Text]
             name_node=None,      # type: typing.Optional[typing.Text]
-            job_xml_files=None,  # type: JobXmlFilesType
-            configuration=None,  # type: PropertyValuesType
+            job_xml_files=None,  # type: typing.Optional[JobXmlFilesType]
+            configuration=None,  # type: typing.Optional[PropertyValuesType]
     ):
         # type: (...) -> None
         super(GlobalConfiguration, self).__init__(xml_tag='global')
@@ -417,12 +417,12 @@ class CoordinatorApp(XMLSerializable):
             start,                        # type: datetime.datetime
             end=None,                     # type: typing.Optional[datetime.datetime]
             timezone=None,                # type: typing.Optional[typing.Text]
-            workflow_configuration=None,  # type: PropertyValuesType
+            workflow_configuration=None,  # type: typing.Optional[PropertyValuesType]
             timeout=None,                 # type: typing.Optional[int]
             concurrency=None,             # type: typing.Optional[int]
             execution_order=None,         # type: typing.Optional[ExecutionOrder]
             throttle=None,                # type: typing.Optional[int]
-            parameters=None               # type: PropertyValuesType
+            parameters=None               # type: typing.Optional[PropertyValuesType]
     ):
         # type: (...) -> None
         super(CoordinatorApp, self).__init__(xml_tag='coordinator-app')

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -19,6 +19,9 @@ COMPILED_REGEX_IDENTIFIER = re.compile(REGEX_IDENTIFIER)
 ALLOWABLE_NAME_CHARS = set(string.ascii_letters + string.punctuation + string.digits + ' ')
 ONE_HUNDRED_YEARS = 100 * 365.24
 
+PropertyValuesType = typing.Optional[typing.Dict[typing.Text, typing.Any]]
+JobXmlFilesType = typing.Optional[typing.Iterable[typing.Text]]
+
 
 class ExecutionOrder(enum.Enum):
     """Execution order used for coordinator jobs."""
@@ -112,8 +115,8 @@ class _PropertyList(XMLSerializable, dict):
     def __init__(
             self,
             xml_tag,          # type: typing.Text
-            attributes=None,  # type: typing.Optional[typing.Dict]
-            values=None       # type: typing.Optional[typing.Dict]
+            attributes=None,  # type: typing.Optional[typing.Dict[typing.Text, typing.Text]]
+            values=None       # type: PropertyValuesType
     ):
         # type: (...) -> None
         super(_PropertyList, self).__init__(xml_tag=xml_tag)
@@ -144,7 +147,7 @@ class Parameters(_PropertyList):
     """
 
     def __init__(self, values=None):
-        # type: (typing.Optional[typing.Dict]) -> None
+        # type: (PropertyValuesType) -> None
         super(Parameters, self).__init__(xml_tag='parameters', values=values)
 
 
@@ -152,7 +155,7 @@ class Configuration(_PropertyList):
     """Coordinator job submission, workflow, workflow action configuration XML."""
 
     def __init__(self, values=None):
-        # type: (typing.Optional[typing.Dict]) -> None
+        # type: (PropertyValuesType) -> None
         super(Configuration, self).__init__(xml_tag='configuration', values=values)
 
 
@@ -177,8 +180,13 @@ class Credential(_PropertyList):
     ```
     """
 
-    def __init__(self, values, credential_name, credential_type):
-        # type: (typing.Dict, typing.Text, typing.Text) -> None
+    def __init__(
+            self,
+            values,           # type: PropertyValuesType
+            credential_name,  # type: typing.Text
+            credential_type   # type: typing.Text
+    ):
+        # type: (...) -> None
         super(Credential, self).__init__(
             xml_tag='credential',
             attributes={
@@ -199,10 +207,10 @@ class Shell(XMLSerializable):
             job_tracker=None,     # type: typing.Optional[typing.Text]
             name_node=None,       # type: typing.Optional[typing.Text]
             prepare=None,         # type: typing.Optional[typing.Sequence]
-            job_xml_files=None,   # type: typing.Optional[typing.Iterable[typing.Text]]
-            configuration=None,   # type: typing.Optional[typing.Dict[typing.Text, typing.Text]]
+            job_xml_files=None,   # type: JobXmlFilesType
+            configuration=None,   # type: PropertyValuesType
             arguments=None,       # type: typing.Optional[typing.Iterable[typing.Text]]
-            env_vars=None,        # type: typing.Optional[typing.Dict[typing.Text, typing.Text]]
+            env_vars=None,        # type: PropertyValuesType
             files=None,           # type: typing.Optional[typing.Iterable[typing.Text]]
             archives=None,        # type: typing.Optional[typing.Iterable[typing.Text]]
             capture_output=False  # type: bool
@@ -278,7 +286,7 @@ class SubWorkflow(XMLSerializable):
             self,
             app_path,                      # type: str
             propagate_configuration=True,  # type: bool
-            configuration=None             # type: typing.Optional[typing.Dict[typing.Text, typing.Text]]
+            configuration=None             # type: PropertyValuesType
     ):
         # type: (...) -> None
         super(SubWorkflow, self).__init__(xml_tag='sub-workflow')
@@ -315,8 +323,8 @@ class GlobalConfiguration(XMLSerializable):
             self,
             job_tracker=None,    # type: typing.Optional[typing.Text]
             name_node=None,      # type: typing.Optional[typing.Text]
-            job_xml_files=None,  # type: typing.Optional[typing.Iterable[typing.Text]]
-            configuration=None,  # type: typing.Optional[typing.Dict[typing.Text, typing.Text]]
+            job_xml_files=None,  # type: JobXmlFilesType
+            configuration=None,  # type: PropertyValuesType
     ):
         # type: (...) -> None
         super(GlobalConfiguration, self).__init__(xml_tag='global')
@@ -409,12 +417,12 @@ class CoordinatorApp(XMLSerializable):
             start,                        # type: datetime.datetime
             end=None,                     # type: typing.Optional[datetime.datetime]
             timezone=None,                # type: typing.Optional[typing.Text]
-            workflow_configuration=None,  # type: typing.Optional[typing.Dict[typing.Text, typing.Text]]
+            workflow_configuration=None,  # type: PropertyValuesType
             timeout=None,                 # type: typing.Optional[int]
             concurrency=None,             # type: typing.Optional[int]
             execution_order=None,         # type: typing.Optional[ExecutionOrder]
             throttle=None,                # type: typing.Optional[int]
-            parameters=None               # type: typing.Optional[typing.Dict[typing.Text, typing.Text]]
+            parameters=None               # type: PropertyValuesType
     ):
         # type: (...) -> None
         super(CoordinatorApp, self).__init__(xml_tag='coordinator-app')

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -90,7 +90,7 @@ class XMLSerializable(object):
 
     @abc.abstractmethod
     def _xml(self, doc, tag, text):
-        # type: (yattag.doc.Doc, typing.Callable, typing.Callable) -> yattag.doc.Doc
+        # type: (yattag.doc.Doc, yattag.doc.Doc.tag, yattag.doc.Doc.text) -> yattag.doc.Doc
         raise NotImplementedError()
 
 
@@ -117,7 +117,7 @@ class _PropertyList(XMLSerializable, dict):
         self.attributes = attributes or {}
 
     def _xml(self, doc, tag, text):
-        # type: (yattag.doc.Doc, typing.Callable, typing.Callable) -> yattag.doc.Doc
+        # type: (yattag.doc.Doc, yattag.doc.Doc.tag, yattag.doc.Doc.text) -> yattag.doc.Doc
         with tag(self.xml_tag, **self.attributes):
             for name, value in sorted(self.items()):
                 with tag('property'):
@@ -217,7 +217,7 @@ class Shell(XMLSerializable):
         self.capture_output = capture_output
 
     def _xml(self, doc, tag, text):
-        # type: (yattag.doc.Doc, typing.Callable, typing.Callable) -> yattag.doc.Doc
+        # type: (yattag.doc.Doc, yattag.doc.Doc.tag, yattag.doc.Doc.text) -> yattag.doc.Doc
         with tag(self.xml_tag, xmlns='uri:oozie:shell-action:0.3'):
             if self.job_tracker:
                 with tag('job-tracker'):
@@ -282,7 +282,7 @@ class SubWorkflow(XMLSerializable):
         self.configuration = Configuration(configuration)
 
     def _xml(self, doc, tag, text):
-        # type: (yattag.doc.Doc, typing.Callable, typing.Callable) -> yattag.doc.Doc
+        # type: (yattag.doc.Doc, yattag.doc.Doc.tag, yattag.doc.Doc.text) -> yattag.doc.Doc
         with tag(self.xml_tag):
             with tag('app-path'):
                 doc.text(self.app_path)
@@ -321,7 +321,7 @@ class GlobalConfiguration(XMLSerializable):
         self.configuration = Configuration(configuration)
 
     def _xml(self, doc, tag, text):
-        # type: (yattag.doc.Doc, typing.Callable, typing.Callable) -> yattag.doc.Doc
+        # type: (yattag.doc.Doc, yattag.doc.Doc.tag, yattag.doc.Doc.text) -> yattag.doc.Doc
         with tag(self.xml_tag):
             if self.job_tracker:
                 with tag('job-tracker'):
@@ -363,7 +363,7 @@ class Email(XMLSerializable):
         self.attachments = attachments
 
     def _xml(self, doc, tag, text):
-        # type: (yattag.doc.Doc, typing.Callable, typing.Callable) -> yattag.doc.Doc
+        # type: (yattag.doc.Doc, yattag.doc.Doc.tag, yattag.doc.Doc.text) -> yattag.doc.Doc
 
         def format_list(strings):
             if hasattr(strings, '__iter__') and not isinstance(strings, six.string_types):
@@ -446,7 +446,7 @@ class CoordinatorApp(XMLSerializable):
         return value.strftime('%Y-%m-%dT%H:%MZ')
 
     def _xml(self, doc, tag, text):
-        # type: (yattag.doc.Doc, typing.Callable, typing.Callable) -> yattag.doc.Doc
+        # type: (yattag.doc.Doc, yattag.doc.Doc.tag, yattag.doc.Doc.text) -> yattag.doc.Doc
 
         with tag(self.xml_tag, xmlns="uri:oozie:coordinator:0.4", name=self.name, frequency=str(self.frequency),
                  start=CoordinatorApp.__format_datetime(self.start), end=CoordinatorApp.__format_datetime(self.end),

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -109,8 +109,13 @@ class _PropertyList(XMLSerializable, dict):
     </xml_tag>
     """
 
-    def __init__(self, xml_tag, attributes=None, values=None):
-        # type: (typing.Text, typing.Dict, typing.Dict) -> None
+    def __init__(
+            self,
+            xml_tag,          # type: typing.Text
+            attributes=None,  # type: typing.Optional[typing.Dict]
+            values=None       # type: typing.Optional[typing.Dict]
+    ):
+        # type: (...) -> None
         super(_PropertyList, self).__init__(xml_tag=xml_tag)
         if values:
             self.update(values)
@@ -139,7 +144,7 @@ class Parameters(_PropertyList):
     """
 
     def __init__(self, values=None):
-        # type: (typing.Dict) -> None
+        # type: (typing.Optional[typing.Dict]) -> None
         super(Parameters, self).__init__(xml_tag='parameters', values=values)
 
 
@@ -147,7 +152,7 @@ class Configuration(_PropertyList):
     """Coordinator job submission, workflow, workflow action configuration XML."""
 
     def __init__(self, values=None):
-        # type: (typing.Dict) -> None
+        # type: (typing.Optional[typing.Dict]) -> None
         super(Configuration, self).__init__(xml_tag='configuration', values=values)
 
 
@@ -190,16 +195,16 @@ class Shell(XMLSerializable):
 
     def __init__(
             self,
-            exec_command,  # type: typing.Text
-            job_tracker=None,  # type: typing.Text
-            name_node=None,  # type: typing.Text
-            prepare=None,  # type: typing.Sequence
-            job_xml_files=None,  # type: typing.Iterable[typing.Text]
-            configuration=None,  # type: typing.Dict[typing.Text, typing.Text]
-            arguments=None,  # type: typing.Iterable[typing.Text]
-            env_vars=None,  # type: typing.Dict[typing.Text, typing.Text]
-            files=None,  # type: typing.Iterable[typing.Text]
-            archives=None,  # type: typing.Iterable[typing.Text]
+            exec_command,         # type: typing.Text
+            job_tracker=None,     # type: typing.Optional[typing.Text]
+            name_node=None,       # type: typing.Optional[typing.Text]
+            prepare=None,         # type: typing.Optional[typing.Sequence]
+            job_xml_files=None,   # type: typing.Optional[typing.Iterable[typing.Text]]
+            configuration=None,   # type: typing.Optional[typing.Dict[typing.Text, typing.Text]]
+            arguments=None,       # type: typing.Optional[typing.Iterable[typing.Text]]
+            env_vars=None,        # type: typing.Optional[typing.Dict[typing.Text, typing.Text]]
+            files=None,           # type: typing.Optional[typing.Iterable[typing.Text]]
+            archives=None,        # type: typing.Optional[typing.Iterable[typing.Text]]
             capture_output=False  # type: bool
     ):
         # type: (...) -> None
@@ -271,9 +276,9 @@ class SubWorkflow(XMLSerializable):
 
     def __init__(
             self,
-            app_path,  # type: str
+            app_path,                      # type: str
             propagate_configuration=True,  # type: bool
-            configuration=None  # type: typing.Dict[typing.Text, typing.Text]
+            configuration=None             # type: typing.Optional[typing.Dict[typing.Text, typing.Text]]
     ):
         # type: (...) -> None
         super(SubWorkflow, self).__init__(xml_tag='sub-workflow')
@@ -308,10 +313,10 @@ class GlobalConfiguration(XMLSerializable):
 
     def __init__(
             self,
-            job_tracker=None,  # type: typing.Text
-            name_node=None,  # typing.Text
-            job_xml_files=None,  # type: typing.Iterable[typing.Text]
-            configuration=None,  # type: typing.Dict[typing.Text, typing.Text]
+            job_tracker=None,    # type: typing.Optional[typing.Text]
+            name_node=None,      # type: typing.Optional[typing.Text]
+            job_xml_files=None,  # type: typing.Optional[typing.Iterable[typing.Text]]
+            configuration=None,  # type: typing.Optional[typing.Dict[typing.Text, typing.Text]]
     ):
         # type: (...) -> None
         super(GlobalConfiguration, self).__init__(xml_tag='global')
@@ -344,13 +349,13 @@ class Email(XMLSerializable):
 
     def __init__(
             self,
-            to,  # type: typing.Union[typing.Text, typing.Iterable[typing.Text]]
-            subject,  # type: typing.Text
-            body,  # type: typing.Text
-            cc=None,  # type: typing.Union[typing.Text, typing.Iterable[typing.Text]]
-            bcc=None,  # type: typing.Union[typing.Text, typing.Iterable[typing.Text]]
-            content_type=None,  # type: typing.Text
-            attachments=None  # type: typing.Text
+            to,                 # type: typing.Union[typing.Text, typing.Iterable[typing.Text]]
+            subject,            # type: typing.Text
+            body,               # type: typing.Text
+            cc=None,            # type: typing.Optional[typing.Union[typing.Text, typing.Iterable[typing.Text]]]
+            bcc=None,           # type: typing.Optional[typing.Union[typing.Text, typing.Iterable[typing.Text]]]
+            content_type=None,  # type: typing.Optional[typing.Text]
+            attachments=None    # type: typing.Optional[typing.Text]
     ):
         # type: (...) -> None
         super(Email, self).__init__(xml_tag='email')
@@ -398,18 +403,18 @@ class CoordinatorApp(XMLSerializable):
 
     def __init__(
             self,
-            name,  # type: typing.Text
-            workflow_app_path,  # type: typing.Text
-            frequency,  # type: int
-            start,  # type: datetime.datetime
-            end=None,  # type: datetime.datetime
-            timezone=None,  # type: typing.Text
-            workflow_configuration=None,  # type: typing.Dict[typing.Text, typing.Text]
-            timeout=None,  # type: int
-            concurrency=None,  # type: int
-            execution_order=None,  # type: ExecutionOrder
-            throttle=None,  # type: int
-            parameters=None  # type: typing.Dict[typing.Text, typing.Text]
+            name,                         # type: typing.Text
+            workflow_app_path,            # type: typing.Text
+            frequency,                    # type: int
+            start,                        # type: datetime.datetime
+            end=None,                     # type: typing.Optional[datetime.datetime]
+            timezone=None,                # type: typing.Optional[typing.Text]
+            workflow_configuration=None,  # type: typing.Optional[typing.Dict[typing.Text, typing.Text]]
+            timeout=None,                 # type: typing.Optional[int]
+            concurrency=None,             # type: typing.Optional[int]
+            execution_order=None,         # type: typing.Optional[ExecutionOrder]
+            throttle=None,                # type: typing.Optional[int]
+            parameters=None               # type: typing.Optional[typing.Dict[typing.Text, typing.Text]]
     ):
         # type: (...) -> None
         super(CoordinatorApp, self).__init__(xml_tag='coordinator-app')

--- a/pyoozie/xml.py
+++ b/pyoozie/xml.py
@@ -55,7 +55,7 @@ class WorkflowBuilder(object):
 
     def build(self, indent=False):
         def format_xml(xml):
-            xml = xml.replace("<?xml version='1.0' encoding='UTF-8'?>", '')
+            xml = xml.decode('utf-8').replace("<?xml version='1.0' encoding='UTF-8'?>", '')
             return '\n'.join([(' ' * 8) + line for line in xml.strip().split('\n')])
         return '''
 <?xml version="1.0" encoding="UTF-8"?>
@@ -81,7 +81,7 @@ class WorkflowBuilder(object):
            action_error_xml=format_xml(self._action_error.xml(indent=indent)),
            kill_message=self._kill_message,
            action_name=self._action_name,
-           name=self._name).strip()
+           name=self._name).strip().encode('utf-8')
 
 
 class CoordinatorBuilder(object):

--- a/tests/data/workflow.xml
+++ b/tests/data/workflow.xml
@@ -19,7 +19,7 @@
         <error to="kill" />
     </action>
     <kill name="kill">
-        <message>Failure message</message>
+        <message>Failure message 😢</message>
     </kill>
     <end name="end" />
 </workflow-app>

--- a/tests/pyoozie/test_client.py
+++ b/tests/pyoozie/test_client.py
@@ -1212,13 +1212,13 @@ class TestOozieClientJobSubmit(object):
                 mock_post.return_value = {'id': SAMPLE_COORD_ID}
 
                 api.jobs_submit_coordinator('/dummy/coord-path')
-                conf = mock_post.call_args[0][1]
+                conf = mock_post.call_args[0][1].decode('utf-8')
                 assert '<name>oozie.coord.application.path</name><value>/dummy/coord-path</value>' in conf
                 assert '<name>user.name</name><value>oozie</value>' in conf
                 mock_post.reset_mock()
 
                 api.jobs_submit_coordinator('/dummy/coord-path', configuration={'test.prop': 'this is a test'})
-                conf = mock_post.call_args[0][1]
+                conf = mock_post.call_args[0][1].decode('utf-8')
                 assert '<name>test.prop</name><value>this is a test</value>' in conf
                 mock_post.reset_mock()
 
@@ -1254,12 +1254,12 @@ class TestOozieClientJobSubmit(object):
                 mock_post.return_value = {'id': SAMPLE_WF_ID}
 
                 api.jobs_submit_workflow('/dummy/wf-path')
-                conf = mock_post.call_args[0][1]
+                conf = mock_post.call_args[0][1].decode('utf-8')
                 assert '<name>oozie.wf.application.path</name><value>/dummy/wf-path</value>' in conf
                 assert '<name>user.name</name><value>oozie</value>' in conf
                 mock_post.reset_mock()
 
                 api.jobs_submit_workflow('/dummy/wf-path', configuration={'test.prop': 'this is a test'})
-                conf = mock_post.call_args[0][1]
+                conf = mock_post.call_args[0][1].decode('utf-8')
                 assert '<name>test.prop</name><value>this is a test</value>' in conf
                 mock_post.reset_mock()

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -190,7 +190,7 @@ def test_shell():
         exec_command='${EXEC}',
         job_tracker='${jobTracker}',
         name_node='${nameNode}',
-        prepares=None,
+        prepare=None,
         job_xml_files=['/user/${wf:user()}/job.xml'],
         configuration={
             'mapred.job.queue.name': '${queueName}'
@@ -225,13 +225,13 @@ def test_shell():
         <capture-output />
     </shell>''') == tests.utils.xml_to_dict_unordered(actual)
 
-    # Test using prepares fails
+    # Test using prepare fails
     with pytest.raises(NotImplementedError) as assertion_info:
         tags.Shell(
             exec_command='${EXEC}',
-            prepares=['anything'],
+            prepare=['anything'],
         ).xml()
-    assert str(assertion_info.value) == "Shell action's prepares has not yet been implemented"
+    assert str(assertion_info.value) == "Shell action's prepare has not yet been implemented"
 
 
 def test_subworkflow():

--- a/tests/pyoozie/test_xml.py
+++ b/tests/pyoozie/test_xml.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals
@@ -35,7 +36,7 @@ def workflow_builder():
         name='payload',
         action=tags.Shell(exec_command='echo "test"'),
         action_on_error=tags.Email(to='person@example.com', subject='Error', body='A bad thing happened'),
-        kill_on_error='Failure message',
+        kill_on_error='Failure message 😢',
     )
 
 
@@ -140,7 +141,7 @@ def test_workflow_builder(tmpdir, workflow_builder):
 
     # Does it validate against the workflow XML schema?
     filename = tmpdir.join("workflow.xml")
-    filename.write_text(actual_xml, encoding='utf8')
+    filename.write_binary(actual_xml)
     try:
         subprocess.check_output(
             'java -cp lib/oozie-client-4.1.0.jar:lib/commons-cli-1.2.jar '


### PR DESCRIPTION
This PR beings to add type hinting to pyoozie by:
  - Adding a `make type` target to speed up testing; and
  - Adds type annotations to `pyoozie.tags`.

During that, a return type change was made: XML output is returned as UTF-8 encoded bytes and not unicode strings. `pyoozie.client.jobs_submit_coordinator` and `pyoozie.client.jobs_submit_workflow`, which both XML output in HTTP POST bodies to Oozie were tested against Oozie 4.1.0 to ensure that they still submit data correctly (which uncovered an issue reading non-ASCII coordinator configurations shown in https://github.com/Shopify/pyoozie/pull/31).