### PR TITLE
Read unicode coordinator configurations

### DIFF
--- a/tests/pyoozie/test_model.py
+++ b/tests/pyoozie/test_model.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # Copyright (c) 2017 "Shopify inc." All rights reserved.
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals
@@ -360,12 +361,12 @@ def test_parse_configuration():
     </property>
     <property>
         <name>key2</name>
-        <value>value2</value>
+        <value>😢</value>
     </property>
 </configuration>
 """
     result = model._parse_configuration(None, conf_string)
-    assert result == {'key1': 'value1', 'key2': 'value2'}
+    assert result == {'key1': 'value1', 'key2': '😢'}
 
 
 @pytest.mark.parametrize("string, expected", [


### PR DESCRIPTION
This PR fixes an issue where if a coordinator configuration contains a non-ASCII character then it fails to parse the configuration with the following exception:

```
self = <xml.sax.expatreader.ExpatParser instance at 0x10bec5368>, data = '
<configuration>
    <property>
        <name>key1</name>
        <value>value1</value>
    </property>
    <property>
        <name>key2</name>
        <value>😢</value>
    </property>
</configuration>
', isFinal = 0

    def feed(self, data, isFinal = 0):
        if not self._parsing:
            self.reset()
            self._parsing = 1
            self._cont_handler.startDocument()

        try:
            # The isFinal parameter is internal to the expat reader.
            # If it is set to true, expat will check validity of the entire
            # document. When feeding chunks, they are not normally final -
            # except when invoked from close.
>           self._parser.Parse(data, isFinal)
E           UnicodeEncodeError: 'ascii' codec can't encode characters in position 160-161: ordinal not in range(128)

/usr/local/opt/pyenv/versions/2.7.13/lib/python2.7/xml/sax/expatreader.py:213: UnicodeEncodeError
```