### PR TITLE
Add workflow tag

### DIFF
--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -42,20 +42,6 @@ EXEC_LIFO = ExecutionOrder.LIFO
 EXEC_NONE = ExecutionOrder.NONE
 
 
-class RetryPolicy(enum.Enum):
-    """Retry policy for workflow actions"""
-
-    EXPONENTIAL = 'EXPONENTIAL'
-    PERIODIC = 'PERIODIC'
-
-    def __str__(self):
-        return self.value
-
-
-RETRY_EXPONENTIAL = RetryPolicy.EXPONENTIAL
-RETRY_PERIODIC = RetryPolicy.PERIODIC
-
-
 def validate_xml_name(name):
     # type: (typing.Text) -> typing.Text
 
@@ -519,9 +505,6 @@ class WorkflowApp(XMLSerializable):
             job_tracker=None,             # type: typing.Optional[typing.Text]
             name_node=None,               # type: typing.Optional[typing.Text]
             job_xml_files=None,           # type: typing.Optional[JobXmlFilesType]
-            default_retry_max=None,       # type: typing.Optional[int]
-            default_retry_interval=None,  # type: typing.Optional[int]
-            default_retry_policy=None     # type: typing.Optional[RetryPolicy]
     ):
         # type: (...) -> None
         XMLSerializable.__init__(self, 'workflow-app')
@@ -535,10 +518,6 @@ class WorkflowApp(XMLSerializable):
             configuration=configuration
         )
         self.credentials = credentials
-
-        self.default_retry_max = default_retry_max
-        self.default_retry_interval = default_retry_interval
-        self.default_retry_policy = default_retry_policy
 
     def _xml(self, doc, tag, text):
         with tag(self.xml_tag, name=self.name, xmlns="uri:oozie:workflow:0.5"):

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -452,9 +452,6 @@ def test_workflow_app():
         job_tracker='job-tracker',
         name_node='name-node',
         job_xml_files=['/user/${wf:user()}/job.xml'],
-        default_retry_max=10,
-        default_retry_interval=1,
-        default_retry_policy=tags.RETRY_PERIODIC
     )
 
     actual_xml = workflow_app.xml(indent=True)

--- a/tests/pyoozie/test_xml.py
+++ b/tests/pyoozie/test_xml.py
@@ -4,7 +4,6 @@
 from __future__ import unicode_literals
 
 import datetime
-import subprocess
 
 import pytest
 import tests.utils
@@ -131,7 +130,7 @@ def test_coordinator_submission_xml_with_configuration(username, coord_app_path)
     </configuration>''') == tests.utils.xml_to_dict_unordered(actual)
 
 
-def test_workflow_builder(tmpdir, workflow_builder):
+def test_workflow_builder(workflow_builder):
     with open('tests/data/workflow.xml', 'r') as fh:
         expected_xml = fh.read()
 
@@ -140,20 +139,7 @@ def test_workflow_builder(tmpdir, workflow_builder):
     assert tests.utils.xml_to_dict_unordered(expected_xml) == tests.utils.xml_to_dict_unordered(actual_xml)
 
     # Does it validate against the workflow XML schema?
-    filename = tmpdir.join("workflow.xml")
-    filename.write_binary(actual_xml)
-    try:
-        subprocess.check_output(
-            'java -cp lib/oozie-client-4.1.0.jar:lib/commons-cli-1.2.jar '
-            'org.apache.oozie.cli.OozieCLI validate {path}'.format(path=str(filename)),
-            stderr=subprocess.STDOUT,
-            shell=True
-        )
-    except subprocess.CalledProcessError as e:
-        raise AssertionError('An XML validation error\n\n{error}\n\noccurred while parsing:\n\n{xml}'.format(
-            error=e.output.decode('utf8').strip(),
-            xml=actual_xml,
-        ))
+    tests.utils.assert_valid_workflow(actual_xml)
 
 
 def test_builder_raises_on_bad_workflow_name():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,6 +2,9 @@
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals
 
+import subprocess
+import tempfile
+
 import xmltodict
 
 
@@ -14,3 +17,24 @@ def xml_to_dict_unordered(xml):
         else:
             return value
     return unorder(xmltodict.parse(xml))
+
+
+def assert_valid_workflow(xml):
+    with tempfile.NamedTemporaryFile() as fp:
+        # Write XML file
+        fp.write(xml)
+        fp.flush()
+
+        # Start a process to validate the XML file
+        try:
+            subprocess.check_output(
+                'java -cp lib/oozie-client-4.1.0.jar:lib/commons-cli-1.2.jar '
+                'org.apache.oozie.cli.OozieCLI validate {path}'.format(path=fp.name),
+                stderr=subprocess.STDOUT,
+                shell=True
+            )
+        except subprocess.CalledProcessError as e:
+            raise AssertionError('An XML validation error\n\n{error}\n\noccurred while parsing:\n\n{xml}'.format(
+                error=e.output.decode('utf8').strip(),
+                xml=xml,
+            ))


### PR DESCRIPTION
This PR adds a basic `workflow-app` tag that simply contains a `start` and `end` with no other work and validates the XML that is generated from it.

An alias is not added to the `pyoozie` package and a warning is issued if it is used because it is not yet finished.

Subsequent PRs will add functionality discussed in https://github.com/Shopify/pyoozie/pull/26, including:
  1. APIs to add a single action;
  2. APIs to add an action on error (allowing us to remove `WorkflowBuilder`);
  3. APIs to add multiple serial action (with actions on error); and then
  4. APIs to add multiple parallel actions (with actions on error).