### PR TITLE
Remove dependency links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ clean:
 		rm -fr *.egg-info
 
 install:
-		pip install -e ".[test]" --process-dependency-links
+		pip install -e ".[test]"
 		test -d lib || mkdir lib
 		test -f lib/oozie-client-4.1.0.jar || \
 			curl http://central.maven.org/maven2/org/apache/oozie/oozie-client/4.1.0/oozie-client-4.1.0.jar -o lib/oozie-client-4.1.0.jar

--- a/setup.py
+++ b/setup.py
@@ -50,13 +50,10 @@ setuplib.setup(
             'pytest-randomly',
             'pytest>=2.7',
             'requests-mock',
-            'shopify_python==0.2.0',
+            'shopify_python==0.2.2',
             'xmltodict',
         ],
     },
-    dependency_links=[
-        'git+https://github.com/Shopify/shopify_python.git@v0.2.0#egg=shopify_python-0.2.0',
-    ],
     license="MIT",
     keywords=['oozie'],
     classifiers=[


### PR DESCRIPTION
This is a [deprecated feature in pip](https://github.com/pypa/pip/blame/master/NEWS.rst#L690), so let's not rely upon it.