### PR TITLE
Replace pep8 with pycodestyle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ type:
 sourcelint:
 		@echo 'Linting...'
 		@pylint --rcfile=pylintrc setup.py pyoozie tests
-		@pep8
+		@pycodestyle
 
 lint: sourcelint type
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
-[pep8]
+[pycodestyle]
 max-line-length = 120
 
 [autopep8]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setuplib.setup(
             'flake8',
             'mock',
             'mypy; python_version >= "3.3"',
-            'pep8',
+            'pycodestyle == 2.2.0',
             'pylint',
             'pytest-cov',
             'pytest-randomly',


### PR DESCRIPTION
[pep8 was renamed](http://pep8.readthedocs.io/en/release-1.7.x/) [pycodestyle](https://github.com/PyCQA/pycodestyle).