### PR TITLE
Add ability to update a coordinator's definition

### DIFF
--- a/pyoozie/client.py
+++ b/pyoozie/client.py
@@ -570,7 +570,7 @@ class OozieClient(object):
                 self.logger.info('Preparing to update coordinator %s:\n%s', xml_path, conf)
             reply = self._put('job/{}?action=update'.format(coordinator_id), conf)
 
-            if 'update' not in reply:
+            if not reply or 'update' not in reply:
                 raise exceptions.OozieException.operation_failed('update coordinator')
 
             if self._verbose:

--- a/tests/pyoozie/test_client.py
+++ b/tests/pyoozie/test_client.py
@@ -1238,6 +1238,7 @@ class TestOozieClientJobSubmit(object):
         with mock.patch.object(api, '_post') as mock_post:
             with mock.patch.object(api, 'job_coordinator_info') as mock_info:
                 mock_info.return_value = sample_coordinator_running
+
                 mock_post.return_value = None
                 with pytest.raises(exceptions.OozieException) as err:
                     api.jobs_submit_coordinator('/dummy/coord-path')
@@ -1260,7 +1261,6 @@ class TestOozieClientJobSubmit(object):
 
                 api.jobs_submit_coordinator('/dummy/coord-path')
                 conf = mock_post.call_args[0][1].decode('utf-8')
-
                 assert '<name>oozie.coord.application.path</name><value>/dummy/coord-path</value>' in conf
                 assert '<name>user.name</name><value>oozie</value>' in conf
                 mock_post.reset_mock()


### PR DESCRIPTION
This adds the ability to update a coordinator's definition without killing and recreating the coordinator.

According to the [docs]( https://oozie.apache.org/docs/4.1.0/DG_CommandLineTool.html#Updating_coordinator_definition_and_properties) a coordinator's definition can only be updated if the following are not changed:
  - coordinator name
  - frequency 
  - start time
  - end time
  - timezone

If any of these are changed, then there should be a hard failure on the [request](https://github.com/Shopify/pyoozie/blob/master/pyoozie/client.py#L144).

I couldn't find anything specific on what coordinator states allow for an update so I assumed we would only want to update coordinators that are `active` or `running` or `suspended`. 

Curious if updating a coordinator in a `suspended` state makes sense.
@kmtaylor-github @cfournie 
Thoughts?