### PR TITLE
Pin Pylint in requirements

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setuplib.setup(
             'mock',
             'mypy; python_version >= "3.3"',
             'pycodestyle == 2.2.0',
-            'pylint',
+            'pylint>=1.6.5,<1.7',
             'pytest-cov',
             'pytest-randomly',
             'pytest>=2.7',


### PR DESCRIPTION
Seems like pylint>1.7 is causing the linter on master to fail with:
```
astroid.exceptions.AstroidImportError: Failed to import module pyoozie.xml.WorkflowBuilder with error:
No module named pyoozie.xml.WorkflowBuilder.
make: *** [sourcelint] Error 1
```
This PR pins pylint to have the same version ranges as [shopify_python](https://github.com/Shopify/shopify_python/blob/master/setup.py).
