### PR TITLE
Add missing is_active tags to some statuses

### DIFF
--- a/pyoozie/model.py
+++ b/pyoozie/model.py
@@ -209,14 +209,14 @@ class CoordinatorActionStatus(_StatusEnum):
     FAILED = _status(1)
     IGNORED = _status(2)
     KILLED = _status(3)
-    READY = _status(4)
+    READY = _status(4, is_active=True)
     RUNNING = _status(5, is_active=True, is_running=True, is_suspendable=True)
     SKIPPED = _status(6)
     SUBMITTED = _status(7, is_active=True)
     SUCCEEDED = _status(8)
     SUSPENDED = _status(9, is_active=True, is_running=True, is_suspended=True)
     TIMEDOUT = _status(10)
-    WAITING = _status(11)
+    WAITING = _status(11, is_active=True)
 
 
 class WorkflowStatus(_StatusEnum):
@@ -238,7 +238,7 @@ class WorkflowActionStatus(_StatusEnum):
     FAILED = _status(5)
     KILLED = _status(6)
     OK = _status(7)
-    PREP = _status(8)
+    PREP = _status(8, is_active=True)
     RUNNING = _status(9, is_active=True, is_running=True)
     START_MANUAL = _status(10)
     START_RETRY = _status(11)

--- a/tests/pyoozie/test_model.py
+++ b/tests/pyoozie/test_model.py
@@ -471,14 +471,14 @@ def test_coordinator_status_predicates(status, active, running, suspendable, sus
     (model.CoordinatorActionStatus.FAILED, False, False, False, False),
     (model.CoordinatorActionStatus.IGNORED, False, False, False, False),
     (model.CoordinatorActionStatus.KILLED, False, False, False, False),
-    (model.CoordinatorActionStatus.READY, False, False, False, False),
+    (model.CoordinatorActionStatus.READY, True, False, False, False),
     (model.CoordinatorActionStatus.RUNNING, True, True, True, False),
     (model.CoordinatorActionStatus.SKIPPED, False, False, False, False),
     (model.CoordinatorActionStatus.SUBMITTED, True, False, False, False),
     (model.CoordinatorActionStatus.SUCCEEDED, False, False, False, False),
     (model.CoordinatorActionStatus.SUSPENDED, True, True, False, True),
     (model.CoordinatorActionStatus.TIMEDOUT, False, False, False, False),
-    (model.CoordinatorActionStatus.WAITING, False, False, False, False),
+    (model.CoordinatorActionStatus.WAITING, True, False, False, False),
 ])
 def test_coordinator_action_status_predicates(status, active, running, suspendable, suspended):
     assert status.is_active() == active
@@ -512,7 +512,7 @@ def test_workflow_status_predicates(status, active, running, suspendable, suspen
     (model.WorkflowActionStatus.FAILED, False, False, False, False),
     (model.WorkflowActionStatus.KILLED, False, False, False, False),
     (model.WorkflowActionStatus.OK, False, False, False, False),
-    (model.WorkflowActionStatus.PREP, False, False, False, False),
+    (model.WorkflowActionStatus.PREP, True, False, False, False),
     (model.WorkflowActionStatus.RUNNING, True, True, False, False),
     (model.WorkflowActionStatus.START_MANUAL, False, False, False, False),
     (model.WorkflowActionStatus.START_RETRY, False, False, False, False),


### PR DESCRIPTION
The `READY`/`WAITING` statuses for coordinator actions weren't tagged as being "active". 
Ditto for `PREP` on workflow actions.

@cfournie @sabidib 