### PR TITLE
Add test utilities

### DIFF
--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -160,13 +160,13 @@ def test_xml_serializable():
 def test_parameters(expected_property_values, expected_property_values_xml):
     actual = tags.Parameters(expected_property_values).xml(indent=True)
     expected = '<parameters>{xml}</parameters>'.format(xml=expected_property_values_xml)
-    assert tests.utils.xml_to_dict_unordered(expected) == tests.utils.xml_to_dict_unordered(actual)
+    assert tests.utils.xml_to_comparable_dict(expected) == tests.utils.xml_to_comparable_dict(actual)
 
 
 def test_configuration(expected_property_values, expected_property_values_xml):
     actual = tags.Configuration(expected_property_values).xml(indent=True)
     expected = '<configuration>{xml}</configuration>'.format(xml=expected_property_values_xml)
-    assert tests.utils.xml_to_dict_unordered(expected) == tests.utils.xml_to_dict_unordered(actual)
+    assert tests.utils.xml_to_comparable_dict(expected) == tests.utils.xml_to_comparable_dict(actual)
 
 
 def test_credential(expected_property_values, expected_property_values_xml):
@@ -175,7 +175,7 @@ def test_credential(expected_property_values, expected_property_values_xml):
                              credential_type='hcat').xml(indent=True)
     expected = "<credential name='my-hcat-creds' type='hcat'>{xml}</credential>".format(
         xml=expected_property_values_xml)
-    assert tests.utils.xml_to_dict_unordered(expected) == tests.utils.xml_to_dict_unordered(actual)
+    assert tests.utils.xml_to_comparable_dict(expected) == tests.utils.xml_to_comparable_dict(actual)
 
 
 def test_shell():
@@ -197,7 +197,7 @@ def test_shell():
         archives=['/users/blabla/testarchive.jar#testarchive'],
         capture_output=True,
     ).xml(indent=True)
-    assert tests.utils.xml_to_dict_unordered('''
+    assert tests.utils.xml_to_comparable_dict('''
     <shell xmlns="uri:oozie:shell-action:0.3">
         <job-tracker>${jobTracker}</job-tracker>
         <name-node>${nameNode}</name-node>
@@ -216,7 +216,7 @@ def test_shell():
         <env-var>ENVIRONMENT=production</env-var>
         <env-var>RESOURCES=large</env-var>
         <capture-output />
-    </shell>''') == tests.utils.xml_to_dict_unordered(actual)
+    </shell>''') == tests.utils.xml_to_comparable_dict(actual)
 
     # Test using prepare fails
     with pytest.raises(NotImplementedError) as assertion_info:
@@ -235,23 +235,23 @@ def test_subworkflow():
         propagate_configuration=False,
         configuration=None,
     ).xml(indent=True)
-    assert tests.utils.xml_to_dict_unordered('''
+    assert tests.utils.xml_to_comparable_dict('''
     <sub-workflow>
         <app-path>/user/username/workflows/cool-flow</app-path>
     </sub-workflow>
-    ''') == tests.utils.xml_to_dict_unordered(actual)
+    ''') == tests.utils.xml_to_comparable_dict(actual)
 
     actual = tags.SubWorkflow(
         app_path=app_path,
         propagate_configuration=True,
         configuration=None,
     ).xml(indent=True)
-    assert tests.utils.xml_to_dict_unordered('''
+    assert tests.utils.xml_to_comparable_dict('''
     <sub-workflow>
         <app-path>/user/username/workflows/cool-flow</app-path>
         <propagate-configuration />
     </sub-workflow>
-    ''') == tests.utils.xml_to_dict_unordered(actual)
+    ''') == tests.utils.xml_to_comparable_dict(actual)
 
     actual = tags.SubWorkflow(
         app_path=app_path,
@@ -261,7 +261,7 @@ def test_subworkflow():
             'name_node': 'hdfs://localhost:50070',
         },
     ).xml(indent=True)
-    assert tests.utils.xml_to_dict_unordered('''
+    assert tests.utils.xml_to_comparable_dict('''
     <sub-workflow>
         <app-path>/user/username/workflows/cool-flow</app-path>
         <propagate-configuration />
@@ -276,7 +276,7 @@ def test_subworkflow():
             </property>
         </configuration>
     </sub-workflow>
-    ''') == tests.utils.xml_to_dict_unordered(actual)
+    ''') == tests.utils.xml_to_comparable_dict(actual)
 
 
 def test_global_configuration():
@@ -290,12 +290,12 @@ def test_global_configuration():
         job_xml_files=None,
         configuration=None,
     ).xml(indent=True)
-    assert tests.utils.xml_to_dict_unordered('''
+    assert tests.utils.xml_to_comparable_dict('''
     <global>
         <job-tracker>a_jobtracker</job-tracker>
         <name-node>hdfs://localhost:50070</name-node>
     </global>
-    ''') == tests.utils.xml_to_dict_unordered(actual)
+    ''') == tests.utils.xml_to_comparable_dict(actual)
 
     actual = tags.GlobalConfiguration(
         job_tracker='a_jobtracker',
@@ -303,7 +303,7 @@ def test_global_configuration():
         job_xml_files=['/user/${wf:user()}/job.xml'],
         configuration=configuration,
     ).xml(indent=True)
-    assert tests.utils.xml_to_dict_unordered('''
+    assert tests.utils.xml_to_comparable_dict('''
     <global>
         <job-tracker>a_jobtracker</job-tracker>
         <name-node>hdfs://localhost:50070</name-node>
@@ -315,7 +315,7 @@ def test_global_configuration():
             </property>
         </configuration>
     </global>
-    ''') == tests.utils.xml_to_dict_unordered(actual)
+    ''') == tests.utils.xml_to_comparable_dict(actual)
 
 
 def test_email():
@@ -324,13 +324,13 @@ def test_email():
         subject='Chains',
         body='Do you need more?',
     ).xml(indent=True)
-    assert tests.utils.xml_to_dict_unordered('''
+    assert tests.utils.xml_to_comparable_dict('''
     <email xmlns="uri:oozie:email-action:0.2">
         <to>mrt@example.com</to>
         <subject>Chains</subject>
         <body>Do you need more?</body>
     </email>
-    ''') == tests.utils.xml_to_dict_unordered(actual)
+    ''') == tests.utils.xml_to_comparable_dict(actual)
 
     actual = tags.Email(
         to='mrt@example.com',
@@ -341,7 +341,7 @@ def test_email():
         content_type='text/plain',
         attachments='/path/to/attachment/on/hdfs.txt',
     ).xml(indent=True)
-    assert tests.utils.xml_to_dict_unordered('''
+    assert tests.utils.xml_to_comparable_dict('''
     <email xmlns="uri:oozie:email-action:0.2">
         <to>mrt@example.com</to>
         <subject>Chains</subject>
@@ -351,7 +351,7 @@ def test_email():
         <content_type>text/plain</content_type>
         <attachment>/path/to/attachment/on/hdfs.txt</attachment>
     </email>
-    ''') == tests.utils.xml_to_dict_unordered(actual)
+    ''') == tests.utils.xml_to_comparable_dict(actual)
 
     actual = tags.Email(
         to=['mrt@example.com', 'b.a.baracus@example.com'],
@@ -363,7 +363,7 @@ def test_email():
         attachments=['/path/on/hdfs.txt',
                      '/another/path/on/hdfs.txt'],
     ).xml(indent=True)
-    assert tests.utils.xml_to_dict_unordered('''
+    assert tests.utils.xml_to_comparable_dict('''
     <email xmlns="uri:oozie:email-action:0.2">
         <to>b.a.baracus@example.com,mrt@example.com</to>
         <subject>Chains</subject>
@@ -373,7 +373,7 @@ def test_email():
         <content_type>text/plain</content_type>
         <attachment>/another/path/on/hdfs.txt,/path/on/hdfs.txt</attachment>
     </email>
-    ''') == tests.utils.xml_to_dict_unordered(actual)
+    ''') == tests.utils.xml_to_comparable_dict(actual)
 
 
 def parse_datetime(string):
@@ -382,12 +382,12 @@ def parse_datetime(string):
 
 def test_minimal_coordinator(minimal_coordinator_options):
     actual_xml = tags.CoordinatorApp(**minimal_coordinator_options).xml(indent=True)
-    actual_dict = tests.utils.xml_to_dict_unordered(actual_xml)
+    actual_dict = tests.utils.xml_to_comparable_dict(actual_xml)
 
     expected_xml = None
     with open('tests/data/minimal_coordinator.xml', 'r') as fh:
         expected_xml = fh.read()
-    expected_dict = tests.utils.xml_to_dict_unordered(expected_xml)
+    expected_dict = tests.utils.xml_to_comparable_dict(expected_xml)
 
     assert actual_dict == expected_dict
 
@@ -409,12 +409,12 @@ def test_full_coordinator(minimal_coordinator_options):
     })
 
     actual_xml = tags.CoordinatorApp(**minimal_coordinator_options).xml(indent=True)
-    actual_dict = tests.utils.xml_to_dict_unordered(actual_xml)
+    actual_dict = tests.utils.xml_to_comparable_dict(actual_xml)
 
     expected_xml = None
     with open('tests/data/full_coordinator.xml', 'r') as fh:
         expected_xml = fh.read()
-    expected_dict = tests.utils.xml_to_dict_unordered(expected_xml)
+    expected_dict = tests.utils.xml_to_comparable_dict(expected_xml)
 
     assert actual_dict == expected_dict
 
@@ -457,8 +457,8 @@ def test_workflow_app():
     )
 
     actual_xml = workflow_app.xml(indent=True)
-    actual_dict = tests.utils.xml_to_dict_unordered(actual_xml)
-    expected_dict = tests.utils.xml_to_dict_unordered("""
+    actual_dict = tests.utils.xml_to_comparable_dict(actual_xml)
+    expected_dict = tests.utils.xml_to_comparable_dict("""
 <workflow-app xmlns="uri:oozie:workflow:0.5" name="descriptive-name">
     <parameters>
         <property>

--- a/tests/pyoozie/test_xml.py
+++ b/tests/pyoozie/test_xml.py
@@ -43,7 +43,7 @@ def test_workflow_submission_xml(username, workflow_app_path):
         workflow_xml_path=workflow_app_path,
         indent=True,
     )
-    assert tests.utils.xml_to_dict_unordered('''
+    assert tests.utils.xml_to_comparable_dict('''
     <configuration>
         <property>
             <name>oozie.wf.application.path</name>
@@ -53,7 +53,7 @@ def test_workflow_submission_xml(username, workflow_app_path):
             <name>user.name</name>
             <value>test</value>
         </property>
-    </configuration>''') == tests.utils.xml_to_dict_unordered(actual)
+    </configuration>''') == tests.utils.xml_to_comparable_dict(actual)
 
 
 def test_workflow_submission_xml_with_configuration(username, workflow_app_path):
@@ -66,7 +66,7 @@ def test_workflow_submission_xml_with_configuration(username, workflow_app_path)
         indent=True
     )
 
-    assert tests.utils.xml_to_dict_unordered('''
+    assert tests.utils.xml_to_comparable_dict('''
     <configuration>
         <property>
             <name>oozie.wf.application.path</name>
@@ -80,7 +80,7 @@ def test_workflow_submission_xml_with_configuration(username, workflow_app_path)
             <name>user.name</name>
             <value>test</value>
         </property>
-    </configuration>''') == tests.utils.xml_to_dict_unordered(actual)
+    </configuration>''') == tests.utils.xml_to_comparable_dict(actual)
 
 
 def test_coordinator_submission_xml(username, coord_app_path):
@@ -89,7 +89,7 @@ def test_coordinator_submission_xml(username, coord_app_path):
         coord_xml_path=coord_app_path,
         indent=True
     )
-    assert tests.utils.xml_to_dict_unordered('''
+    assert tests.utils.xml_to_comparable_dict('''
     <configuration>
         <property>
             <name>oozie.coord.application.path</name>
@@ -99,7 +99,7 @@ def test_coordinator_submission_xml(username, coord_app_path):
             <name>user.name</name>
             <value>test</value>
         </property>
-    </configuration>''') == tests.utils.xml_to_dict_unordered(actual)
+    </configuration>''') == tests.utils.xml_to_comparable_dict(actual)
 
 
 def test_coordinator_submission_xml_with_configuration(username, coord_app_path):
@@ -111,7 +111,7 @@ def test_coordinator_submission_xml_with_configuration(username, coord_app_path)
         },
         indent=True
     )
-    assert tests.utils.xml_to_dict_unordered('''
+    assert tests.utils.xml_to_comparable_dict('''
     <configuration>
         <property>
             <name>oozie.coord.application.path</name>
@@ -125,7 +125,7 @@ def test_coordinator_submission_xml_with_configuration(username, coord_app_path)
             <name>user.name</name>
             <value>test</value>
         </property>
-    </configuration>''') == tests.utils.xml_to_dict_unordered(actual)
+    </configuration>''') == tests.utils.xml_to_comparable_dict(actual)
 
 
 def test_workflow_builder(workflow_builder):
@@ -134,7 +134,7 @@ def test_workflow_builder(workflow_builder):
 
     # Is this XML expected
     actual_xml = workflow_builder.build()
-    assert tests.utils.xml_to_dict_unordered(expected_xml) == tests.utils.xml_to_dict_unordered(actual_xml)
+    assert tests.utils.xml_to_comparable_dict(expected_xml) == tests.utils.xml_to_comparable_dict(actual_xml)
 
     # Does it validate against the workflow XML schema?
     tests.utils.assert_valid_workflow(actual_xml)

--- a/tests/pyoozie/test_xml.py
+++ b/tests/pyoozie/test_xml.py
@@ -69,12 +69,12 @@ def test_workflow_submission_xml_with_configuration(username, workflow_app_path)
     assert tests.utils.xml_to_dict_unordered('''
     <configuration>
         <property>
-            <name>other.key</name>
-            <value>other value</value>
-        </property>
-        <property>
             <name>oozie.wf.application.path</name>
             <value>/user/oozie/workflows/descriptive-name</value>
+        </property>
+        <property>
+            <name>other.key</name>
+            <value>other value</value>
         </property>
         <property>
             <name>user.name</name>

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -70,7 +70,7 @@ def test_assert_valid_workflow(valid_workflow):
         tests.utils.assert_valid_workflow(xml)
     assert str(assertion_info.value) == 'Name(s) reused: alpha'
 
-    # With valid XML, a missing a start tag should result in a schema violation assertion error
+    # With valid XML, a missing start tag should result in a schema violation assertion error
     with pytest.raises(AssertionError) as assertion_info:
         xml = """
 <workflow-app xmlns="uri:oozie:workflow:0.5" name="descriptive-name">
@@ -119,7 +119,7 @@ def test_parsed_xml_assert_node(valid_workflow):
     # Asserting that a node has a specific attribute should pass
     app.assert_node('/start', to='end')
 
-    # Asserting that a node has a specific attribute value that it doens't should raise an assertion error
+    # Asserting that a node has a specific attribute value that it doesn't should raise an assertion error
     with pytest.raises(AssertionError) as assertion_info:
         app.assert_node('/start', to=str('not_end'))
     assert str(assertion_info.value) == str("{'to': 'not_end'} != {'to': 'end'}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,11 +39,17 @@ def test_xml_to_dict_unordered():
   <tag />
   <tag key="value" />
   <tag>Text</tag>
+  <tag key="value">Text</tag>
 </root>
     """.strip())
     assert document_dict == {
         'root': {
-            'tag': [None, u'Text', {'@key': 'value'}]
+            'tag': [
+                None,
+                'Text',
+                {'#text': 'Text', '@key': 'value'},
+                {'@key': 'value'}
+            ]
         }
     }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -34,8 +34,8 @@ def valid_workflow():
 """.strip()
 
 
-def test_xml_to_dict_unordered():
-    document_dict = tests.utils.xml_to_dict_unordered("""
+def test_xml_to_comparable_dict():
+    document_dict = tests.utils.xml_to_comparable_dict("""
 <root>
   <tag />
   <tag key="value" />

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,13 +46,13 @@ def test_xml_to_dict_unordered():
     """.strip())
     assert document_dict == {
         'root': {
-            'tag': [
+            'tag': (
                 None,
+                {'@key': 'value'},
                 'Text',
-                {'#text': 'Text', '@different-key': 'different-value'},
                 {'#text': 'Text', '@key': 'value'},
-                {'@key': 'value'}
-            ]
+                {'#text': 'Text', '@different-key': 'different-value'}
+            )
         }
     }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,124 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2017 "Shopify inc." All rights reserved.
+# Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
+from __future__ import unicode_literals
+
+import xml.etree.ElementTree as et
+
+import pytest
+import tests.utils
+
+
+@pytest.fixture
+def valid_workflow():
+    return """
+<workflow-app xmlns="uri:oozie:workflow:0.5" name="descriptive-name">
+    <parameters>
+        <property>
+            <name>property_key</name>
+            <value>property_value</value>
+        </property>
+        <property>
+            <name>other_property_key</name>
+            <value>🤣</value>
+        </property>
+    </parameters>
+    <global>
+        <job-tracker>job-tracker</job-tracker>
+        <name-node>name-node</name-node>
+    </global>
+    <start to="end" />
+    <end name="end" />
+</workflow-app>
+""".strip()
+
+
+def test_xml_to_dict_unordered():
+    document_dict = tests.utils.xml_to_dict_unordered("""
+<root>
+  <tag />
+  <tag key="value" />
+  <tag>Text</tag>
+</root>
+    """.strip())
+    assert document_dict == {
+        'root': {
+            'tag': [None, u'Text', {'@key': 'value'}]
+        }
+    }
+
+
+def test_assert_valid_workflow(valid_workflow):
+    # A minimal workflow should validate
+    tests.utils.assert_valid_workflow(valid_workflow)
+
+    # With valid XML, duplicate names should raise an assertion error
+    with pytest.raises(AssertionError) as assertion_info:
+        xml = """
+<workflow-app xmlns="uri:oozie:workflow:0.5" name="descriptive-name">
+    <action name="alpha"/>
+    <action name="alpha"/>
+    <action name="beta"/>
+</workflow-app>""".strip()
+        assert len(et.fromstring(xml)), 'Invalid test XML'
+        tests.utils.assert_valid_workflow(xml)
+    assert str(assertion_info.value) == 'Name(s) reused: alpha'
+
+    # With valid XML, a missing a start tag should result in a schema violation assertion error
+    with pytest.raises(AssertionError) as assertion_info:
+        xml = """
+<workflow-app xmlns="uri:oozie:workflow:0.5" name="descriptive-name">
+    <global>
+        <job-tracker>job-tracker</job-tracker>
+        <name-node>name-node</name-node>
+    </global>
+    <end name="end" />
+</workflow-app>""".strip()
+        assert len(et.fromstring(xml)), 'Invalid test XML'
+        tests.utils.assert_valid_workflow(xml)
+    assert str(assertion_info.value).strip() == str(
+        '''An XML validation error occurred.
+
+Error: Invalid app definition, org.xml.sax.SAXParseException; lineNumber: 6; columnNumber: 23; '''
+        '''cvc-complex-type.2.4.a: Invalid content was found starting with element 'end'. One of '''
+        ''''{"uri:oozie:workflow:0.5":credentials, "uri:oozie:workflow:0.5":start}' is expected.
+
+Parsing:
+
+''' + xml).strip()
+
+    # With invalid XML, a parsing error should occur
+    with pytest.raises(et.ParseError) as assertion_info:
+        xml = '<workflow-app xmlns="uri:oozie:workflow:0.5" name="descriptive-name">'
+        tests.utils.assert_valid_workflow(xml)
+    assert str(assertion_info.value) == 'no element found: line 1, column 38'
+
+
+def test_parsed_xml_assert_node(valid_workflow):
+    app = tests.utils.ParsedXml(valid_workflow)
+
+    # Asserting that a node that exists (once) should pass
+    app.assert_node('/global')
+
+    # Asserting that a node that doesn't exists should raise an assertion error
+    with pytest.raises(AssertionError) as assertion_info:
+        app.assert_node('/not_a_tag')
+    assert str(assertion_info.value) == str("Could not find xml tag at xpath '/not_a_tag'")
+
+    # Asserting that a node that exists (when it does multiple times) should raise an assertion error
+    with pytest.raises(AssertionError) as assertion_info:
+        app.assert_node('/parameters/property')
+    assert str(assertion_info.value) == str("Found more than one resolution of xpath '/parameters/property'")
+
+    # Asserting that a node has a specific attribute should pass
+    app.assert_node('/start', to='end')
+
+    # Asserting that a node has a specific attribute value that it doens't should raise an assertion error
+    with pytest.raises(AssertionError) as assertion_info:
+        app.assert_node('/start', to=str('not_end'))
+    assert str(assertion_info.value) == str("{'to': 'not_end'} != {'to': 'end'}")
+
+    # Asserting that a node has a specific attribute that it's missing should raise an assertion error
+    with pytest.raises(AssertionError) as assertion_info:
+        app.assert_node('/start', not_a_key=str('end'))
+    assert str(assertion_info.value) == str("{'not_a_key': 'end'} != {'to': 'end'}")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,13 +46,13 @@ def test_xml_to_dict_unordered():
     """.strip())
     assert document_dict == {
         'root': {
-            'tag': (
+            'tag': [
                 None,
+                {'#text': 'Text', '@different-key': 'different-value'},
+                {'#text': 'Text', '@key': 'value'},
                 {'@key': 'value'},
                 'Text',
-                {'#text': 'Text', '@key': 'value'},
-                {'#text': 'Text', '@different-key': 'different-value'}
-            )
+            ]
         }
     }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -85,16 +85,12 @@ def test_assert_valid_workflow(valid_workflow):
 </workflow-app>""".strip()
         assert len(et.fromstring(xml)), 'Invalid test XML'
         tests.utils.assert_valid_workflow(xml)
-    assert str(assertion_info.value).strip() == str(
-        '''An XML validation error occurred.
-
-Error: Invalid app definition, org.xml.sax.SAXParseException; lineNumber: 6; columnNumber: 23; '''
-        '''cvc-complex-type.2.4.a: Invalid content was found starting with element 'end'. One of '''
-        ''''{"uri:oozie:workflow:0.5":credentials, "uri:oozie:workflow:0.5":start}' is expected.
-
-Parsing:
-
-''' + xml).strip()
+    exception_message = str(assertion_info.value)
+    assert 'An XML validation error occurred.' in exception_message
+    assert 'Error: Invalid app definition, org.xml.sax.SAXParseException; lineNumber: 6; columnNumber: 23;''' in exception_message
+    assert 'Invalid content was found starting with element \'end\'.' in exception_message
+    assert '\'{"uri:oozie:workflow:0.5":credentials, "uri:oozie:workflow:0.5":start}\' is expected.' in exception_message
+    assert  xml in exception_message
 
     # With invalid XML, a parsing error should occur
     with pytest.raises(et.ParseError) as assertion_info:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,7 +13,7 @@ import tests.utils
 @pytest.fixture
 def valid_workflow():
     return """
-<workflow-app xmlns="uri:oozie:workflow:0.5" name="descriptive-name">
+<workflow-app xmlns="uri:oozie:workflow:0.5" xmlns:fake="fake:0.0" name="descriptive-name">
     <parameters>
         <property>
             <name>property_key</name>

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -87,10 +87,12 @@ def test_assert_valid_workflow(valid_workflow):
         tests.utils.assert_valid_workflow(xml)
     exception_message = str(assertion_info.value)
     assert 'An XML validation error occurred.' in exception_message
-    assert 'Error: Invalid app definition, org.xml.sax.SAXParseException; lineNumber: 6; columnNumber: 23;''' in exception_message
+    assert ('Error: Invalid app definition, org.xml.sax.SAXParseException; lineNumber: 6; columnNumber: 23;' in
+            exception_message)
     assert 'Invalid content was found starting with element \'end\'.' in exception_message
-    assert '\'{"uri:oozie:workflow:0.5":credentials, "uri:oozie:workflow:0.5":start}\' is expected.' in exception_message
-    assert  xml in exception_message
+    assert ('\'{"uri:oozie:workflow:0.5":credentials, "uri:oozie:workflow:0.5":start}\' is expected.' in
+            exception_message)
+    assert xml in exception_message
 
     # With invalid XML, a parsing error should occur
     with pytest.raises(et.ParseError) as assertion_info:
@@ -116,12 +118,12 @@ def test_parsed_xml_assert_node(valid_workflow):
     assert str(assertion_info.value) == str("Found more than one resolution of xpath '/parameters/property'")
 
     app.assert_node('/global/name-node', 'name-node-🙄')
-    
+
     # Asserting that a node has a specific text value when it doesn't should raise an error
     with pytest.raises(AssertionError) as assertion_info:
         app.assert_node('/global/name-node', 'name-node')
     assert six.text_type(assertion_info.value) == 'name-node-🙄 != name-node'
-    
+
     # Asserting that a node has a specific attribute should pass
     app.assert_node('/start', to='end')
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -129,10 +129,10 @@ def test_parsed_xml_assert_node(valid_workflow):
 
     # Asserting that a node has a specific attribute value that it doesn't should raise an assertion error
     with pytest.raises(AssertionError) as assertion_info:
-        app.assert_node('/start', to=str('not_end'))
+        app.assert_node('/start', to='not_end')
     assert str(assertion_info.value) == str("{'to': 'not_end'} != {'to': 'end'}")
 
     # Asserting that a node has a specific attribute that it's missing should raise an assertion error
     with pytest.raises(AssertionError) as assertion_info:
-        app.assert_node('/start', not_a_key=str('end'))
+        app.assert_node('/start', not_a_key='end')
     assert str(assertion_info.value) == str("{'not_a_key': 'end'} != {'to': 'end'}")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -2,9 +2,13 @@
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals
 
+import collections
+import re
 import subprocess
 import tempfile
+import xml.etree.ElementTree as et
 
+import six
 import xmltodict
 
 
@@ -19,7 +23,45 @@ def xml_to_dict_unordered(xml):
     return unorder(xmltodict.parse(xml))
 
 
+NAMESPACE_ATTRIBUTE = re.compile(' xmlns="[^"]+"', flags=re.UNICODE)
+
+
+class ParsedXml(object):
+
+    def __init__(self, xml_string):
+        if isinstance(xml_string, six.binary_type):
+            xml_string = xml_string.decode('utf-8')
+        xml_string = NAMESPACE_ATTRIBUTE.sub(str(''), xml_string.strip())
+        self.tree = et.ElementTree(et.fromstring(xml_string.encode('utf-8')))
+
+    def __get_elements(self, xpath):
+        elements = self.tree.findall(xpath)
+        assert elements, "Could not find xml tag at xpath '%s'" % xpath
+        return elements
+
+    def __get_element(self, xpath):
+        elements = self.__get_elements(xpath)
+        assert len(elements) == 1, \
+            "Found more than one resolution of xpath '%s'" % xpath
+        return elements[0]
+
+    def assert_node(self, xpath, **kwargs):
+        element = self.__get_element(xpath)
+        if kwargs:
+            assert set(kwargs.items()) <= set(element.attrib.items()), '%r != %r' % (kwargs, element.attrib)
+
+
 def assert_valid_workflow(xml):
+    # Check for duplicate names (valid XML and valid schema, but logically invalid)
+    names = ParsedXml(xml).tree.findall('.//*[@name]')
+    names = [name.attrib['name'] for name in names]
+    duplicate_names = [item for item, count in collections.Counter(names).items() if count > 1]
+    assert not duplicate_names, 'Name(s) reused: %s' % ', '.join(sorted(duplicate_names))
+
+    if isinstance(xml, six.text_type):
+        xml = xml.encode('utf-8')
+
+    # Call Oozie to validate XML against the schema
     with tempfile.NamedTemporaryFile() as fp:
         # Write XML file
         fp.write(xml)
@@ -34,7 +76,7 @@ def assert_valid_workflow(xml):
                 shell=True
             )
         except subprocess.CalledProcessError as e:
-            raise AssertionError('An XML validation error\n\n{error}\n\noccurred while parsing:\n\n{xml}'.format(
+            raise AssertionError('An XML validation error occurred.\n\n{error}\n\nParsing:\n\n{xml}'.format(
                 error=e.output.decode('utf8').strip(),
-                xml=xml,
+                xml=xml.decode('utf-8'),
             ))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -27,6 +27,7 @@ NAMESPACE_ATTRIBUTE = re.compile(' xmlns="[^"]+"', flags=re.UNICODE)
 
 
 class ParsedXml(object):
+    """Parses an XML string and provides methods to make assertions about the resulting element tree."""
 
     def __init__(self, xml_string):
         if isinstance(xml_string, six.binary_type):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -49,7 +49,9 @@ class ParsedXml(object):
     def assert_node(self, xpath, *args, **kwargs):
         element = self.__get_element(xpath)
         if kwargs:
-            assert set(kwargs.items()) <= set(element.attrib.items()), '%r != %r' % (kwargs, element.attrib)
+            assert set(kwargs.items()) <= set(element.attrib.items()), (
+                ('%r != %r' % (kwargs, element.attrib))
+                .replace(": u'", ": '"))
         if args:
             assert len(args) == 1, 'Too many positional arguments specified'
             assert element.text == args[0], '%s != %s' % (element.text, args[0])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -23,7 +23,7 @@ def xml_to_dict_unordered(xml):
     return unorder(xmltodict.parse(xml))
 
 
-NAMESPACE_ATTRIBUTE = re.compile(' xmlns="[^"]+"', flags=re.UNICODE)
+NAMESPACE_ATTRIBUTE = re.compile(r' xmlns:?[a-z0-9]*="[^"]+"', flags=re.UNICODE)
 
 
 class ParsedXml(object):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,7 +12,7 @@ import six
 import xmltodict
 
 
-def xml_to_dict_unordered(xml):
+def xml_to_comparable_dict(xml):
     def unorder(value):
         if hasattr(value, 'items'):
             return {k: unorder(v) for k, v in value.items()}

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -53,7 +53,7 @@ class ParsedXml(object):
         if args:
             assert len(args) == 1, 'Too many positional arguments specified'
             assert element.text == args[0], '%s != %s' % (element.text, args[0])
-            
+
 
 def assert_valid_workflow(xml):
     # Check for duplicate names (valid XML and valid schema, but logically invalid)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,8 +16,8 @@ def xml_to_dict_unordered(xml):
     def unorder(value):
         if hasattr(value, 'items'):
             return {k: unorder(v) for k, v in value.items()}
-        elif isinstance(value, list):
-            return tuple(unorder(v) for v in value)
+        elif isinstance(value, (tuple, set, list)):
+            return sorted([unorder(v) for v in value], key=lambda v: str(sorted(v) if v is not None else v))
         else:
             return value
     return unorder(xmltodict.parse(xml))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,7 +17,7 @@ def xml_to_dict_unordered(xml):
         if hasattr(value, 'items'):
             return {k: unorder(v) for k, v in value.items()}
         elif isinstance(value, list):
-            return sorted([unorder(v) for v in value], key=str)
+            return tuple(unorder(v) for v in value)
         else:
             return value
     return unorder(xmltodict.parse(xml))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,11 +46,14 @@ class ParsedXml(object):
             "Found more than one resolution of xpath '%s'" % xpath
         return elements[0]
 
-    def assert_node(self, xpath, **kwargs):
+    def assert_node(self, xpath, *args, **kwargs):
         element = self.__get_element(xpath)
         if kwargs:
             assert set(kwargs.items()) <= set(element.attrib.items()), '%r != %r' % (kwargs, element.attrib)
-
+        if args:
+            assert len(args) == 1, 'Too many positional arguments specified'
+            assert element.text == args[0], '%s != %s' % (element.text, args[0])
+            
 
 def assert_valid_workflow(xml):
     # Check for duplicate names (valid XML and valid schema, but logically invalid)


### PR DESCRIPTION
This PR adds/changes utilities to make testing Oozie workflow XML a bit easier.  Specifically:
- `ParsedXml` will parse an XML string once using `ElementTree` and then allows users to assert using XPath that a single tag:
  - Exists; or
  - Has some specific attribute values
- `assert_valid_workflow` checks to make sure that duplicate names are not defined (and fixes an encoding issue)

These are used to test XML workflow generation in https://github.com/Shopify/pyoozie/pull/46.