### PR TITLE
Leave conf None if not provided

### DIFF
--- a/pyoozie/model.py
+++ b/pyoozie/model.py
@@ -91,11 +91,14 @@ def _parse_time(_, time_string):
 
 
 def _parse_configuration(_, conf_string):
-    if conf_string:
+    if conf_string is None:
+        return None
+    elif conf_string:
         xml = conf_string if sys.version_info >= (3, 0) else conf_string.encode('utf-8')
         conf = untangle.parse(xml).configuration
         return {prop.name.cdata: prop.value.cdata for prop in conf.property}
-    return {}
+    else:
+        return {}
 
 
 def _parse_workflow_actions(artifact, actions_list):


### PR DESCRIPTION
The `fill_in_details()` mechanism relies on detecting that the `conf` field of `Coordinator` and `Workflow` objects was not provided (typical in bulk queries), and does a specific query to fetch the additional information. This change ensures that the parse function preserves `None`.

This is a bug introduced while getting lint to run clean; at one point parsing functions were skipped on null inputs, but the linter saw that as uninitialized variables.

@cfournie @sabidib 
