### PR TITLE
Fix flaky XML comparison

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,11 +37,20 @@ def valid_workflow():
 def test_xml_to_comparable_dict():
     document_dict = tests.utils.xml_to_comparable_dict("""
 <root>
+
+  <!-- Various tag forms -->
   <tag />
   <tag key="value" />
   <tag>Text</tag>
   <tag key="value">Text</tag>
   <tag different-key="different-value"> Text </tag>
+
+  <!-- Nested dicts -->
+  <fork name="fork-name">
+    <path start="path-1" />
+    <path start="path-2" />
+  </fork>
+
 </root>
     """.strip())
     assert document_dict == {
@@ -51,8 +60,15 @@ def test_xml_to_comparable_dict():
                 {'#text': 'Text', '@different-key': 'different-value'},
                 {'#text': 'Text', '@key': 'value'},
                 {'@key': 'value'},
-                'Text',
-            ]
+                'Text'
+            ],
+            'fork': {
+                '@name': 'fork-name',
+                'path': [
+                    {'@start': 'path-1'},
+                    {'@start': 'path-2'}
+                ]
+            }
         }
     }
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -41,7 +41,7 @@ def test_xml_to_comparable_dict():
   <!-- Various tag forms -->
   <tag />
   <tag key="value" />
-  <tag>Text</tag>
+  <tag>Text 🤣</tag>
   <tag key="value">Text</tag>
   <tag different-key="different-value"> Text </tag>
 
@@ -56,11 +56,11 @@ def test_xml_to_comparable_dict():
     assert document_dict == {
         'root': {
             'tag': [
-                'Text',
                 None,
+                'Text 🤣',
                 {'#text': 'Text', '@different-key': 'different-value'},
                 {'#text': 'Text', '@key': 'value'},
-                {'@key': 'value'}
+                {'@key': 'value'},
             ],
             'fork': {
                 '@name': 'fork-name',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -56,11 +56,11 @@ def test_xml_to_comparable_dict():
     assert document_dict == {
         'root': {
             'tag': [
+                'Text',
                 None,
                 {'#text': 'Text', '@different-key': 'different-value'},
                 {'#text': 'Text', '@key': 'value'},
-                {'@key': 'value'},
-                'Text'
+                {'@key': 'value'}
             ],
             'fork': {
                 '@name': 'fork-name',

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,16 +13,16 @@ import xmltodict
 
 
 def xml_to_comparable_dict(xml):
-    
+
     def _sort_key(value):
         """Recursively sort lists embedded within dicts."""
         if hasattr(value, 'items'):
-            return repr(sorted([(k, _sort_key(v)) for k, v in value.items()]))
+            return six.text_type(sorted([(k, _sort_key(v)) for k, v in value.items()]))
         elif isinstance(value, (tuple, set, list)):
-            return repr(sorted(value, key=_sort_key))
+            return six.text_type(sorted(value, key=_sort_key))
         else:
-            return repr(value)
-        
+            return six.text_type(value)
+
     def _unorder(value):
         """Convert from a `collections.OrderedDict` to a `dict` with predictably sorted lists."""
         if hasattr(value, 'items'):
@@ -31,6 +31,7 @@ def xml_to_comparable_dict(xml):
             return sorted(tuple(_unorder(v) for v in value), key=_sort_key)
         else:
             return value
+
     return _unorder(xmltodict.parse(xml))
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,14 +13,25 @@ import xmltodict
 
 
 def xml_to_comparable_dict(xml):
-    def unorder(value):
+    
+    def _sort_key(value):
+        """Recursively sort lists embedded within dicts."""
         if hasattr(value, 'items'):
-            return {k: unorder(v) for k, v in value.items()}
+            return repr(sorted([(k, _sort_key(v)) for k, v in value.items()]))
         elif isinstance(value, (tuple, set, list)):
-            return sorted([unorder(v) for v in value], key=lambda v: str(sorted(v) if v is not None else v))
+            return repr(sorted(value, key=_sort_key))
+        else:
+            return repr(value)
+        
+    def _unorder(value):
+        """Convert from a `collections.OrderedDict` to a `dict` with predictably sorted lists."""
+        if hasattr(value, 'items'):
+            return {k: _unorder(v) for k, v in value.items()}
+        elif isinstance(value, (tuple, set, list)):
+            return sorted(tuple(_unorder(v) for v in value), key=_sort_key)
         else:
             return value
-    return unorder(xmltodict.parse(xml))
+    return _unorder(xmltodict.parse(xml))
 
 
 NAMESPACE_ATTRIBUTE = re.compile(r' xmlns:?[a-z0-9]*="[^"]+"', flags=re.UNICODE)


### PR DESCRIPTION
### Problem
When testing https://github.com/Shopify/pyoozie/pull/46, sometimes XML comparisons would fail due to the ordering of lists of dicts (this happens maybe 10% of the time).

```
...
E             'fork': {'@name': 'fork-00000005',
E             -                            'path': [{'@start': 'action-00000000'},
E             ?                                                               ^
E             +                            'path': [{'@start': 'action-00000001'},
E             ?                                                               ^
E             -                                     {'@start': 'action-00000001'}]},
E             ?                                                               ^
E             +                                     {'@start': 'action-00000000'}]},
E             ?                                                               ^
...
```

### Solution
This PR refactors `xml_to_comparable_dict` to convert `collections.OrderedDict` to a `dict` in `_unorder`, and if there's a list, it tries to predictably  sort it by recursing through a value's contents and getting a hashable object for each type in `_sort_key`.

cc/ @Shopify/data-acceleration 