### PR TITLE
Add basic workflow generation

### DIFF
--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -60,6 +60,7 @@ __all__ = (
     'parse_workflow_id',
 
     # tags
+    'Action',
     'Configuration',
     'CoordinatorApp',
     'Credential',
@@ -70,9 +71,11 @@ __all__ = (
     'EXEC_LIFO',
     'EXEC_NONE',
     'GlobalConfiguration',
+    'Kill',
     'Parameters',
     'Shell',
     'SubWorkflow',
     'validate_xml_id',
     'validate_xml_name',
+    'WorkflowApp'
 )

--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -18,6 +18,7 @@ from pyoozie.model import WorkflowStatus
 from pyoozie.model import parse_coordinator_id
 from pyoozie.model import parse_workflow_id
 
+from pyoozie.tags import Action
 from pyoozie.tags import Configuration
 from pyoozie.tags import CoordinatorApp
 from pyoozie.tags import Credential
@@ -28,11 +29,13 @@ from pyoozie.tags import EXEC_LAST_ONLY
 from pyoozie.tags import EXEC_LIFO
 from pyoozie.tags import EXEC_NONE
 from pyoozie.tags import GlobalConfiguration
+from pyoozie.tags import Kill
 from pyoozie.tags import Parameters
 from pyoozie.tags import Shell
 from pyoozie.tags import SubWorkflow
 from pyoozie.tags import validate_xml_id
 from pyoozie.tags import validate_xml_name
+from pyoozie.tags import WorkflowApp
 
 
 __version__ = '0.0.0'

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -496,7 +496,7 @@ class CoordinatorApp(XMLSerializable):
         return doc
 
 
-class _WorkflowEntity(typing.Iterable):
+class _AbstractWorkflowEntity(typing.Iterable):
     """An abstract object representing an Oozie workflow action that can be serialized to XML."""
     # pylint: disable=abstract-method
 
@@ -506,7 +506,7 @@ class _WorkflowEntity(typing.Iterable):
             self,
             xml_tag,       # typing.Text
             name=None,     # type: typing.Optional[typing.Text]
-            on_error=None  # type: typing.Optional[_WorkflowEntity]
+            on_error=None  # type: typing.Optional[_AbstractWorkflowEntity]
     ):
         # type: (...) -> None
         self.__xml_tag = xml_tag
@@ -538,7 +538,7 @@ class _WorkflowEntity(typing.Iterable):
         raise NotImplementedError()
 
     def __iter__(self):
-        # type: () -> typing.Generator[_WorkflowEntity, None, None]
+        # type: () -> typing.Generator[_AbstractWorkflowEntity, None, None]
         yield self
         if self.__on_error:
             for action in self.__on_error:
@@ -554,7 +554,7 @@ class _WorkflowEntity(typing.Iterable):
         return str('<{_class}({identifier})>'.format(_class=type(self).__name__, identifier=self.identifier()))
 
 
-class Kill(_WorkflowEntity):
+class Kill(_AbstractWorkflowEntity):
     """Workflow graph terminal node(s) to end upon to indicate failure."""
 
     def __init__(self, message, name=None):
@@ -573,7 +573,7 @@ class Kill(_WorkflowEntity):
 ConcreteAction = typing.Union[Shell, SubWorkflow, Email]
 
 
-class Action(_WorkflowEntity):
+class Action(_AbstractWorkflowEntity):
     """Workflow action nodes carrying concrete actions that perform an action."""
 
     def __init__(
@@ -583,7 +583,7 @@ class Action(_WorkflowEntity):
             credential=None,      # type: typing.Optional[typing.Text]
             retry_max=None,       # type: typing.Optional[int]
             retry_interval=None,  # type: typing.Optional[int]
-            on_error=None         # type: typing.Optional[_WorkflowEntity]
+            on_error=None         # type: typing.Optional[_AbstractWorkflowEntity]
     ):
         # type: (...) -> None
         super(Action, self).__init__(xml_tag='action', name=name, on_error=on_error)
@@ -630,7 +630,7 @@ class WorkflowApp(XMLSerializable):
             job_tracker=None,             # type: typing.Optional[typing.Text]
             name_node=None,               # type: typing.Optional[typing.Text]
             job_xml_files=None,           # type: typing.Optional[JobXmlFilesType]
-            entities=None,                # type: typing.Optional[_WorkflowEntity]
+            entities=None,                # type: typing.Optional[_AbstractWorkflowEntity]
     ):
         # type: (...) -> None
         XMLSerializable.__init__(self, 'workflow-app')

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -551,7 +551,7 @@ class _WorkflowEntity(typing.Iterable):
         return self.__bool__()
 
     def __repr__(self):  # type: () -> str
-        return str('{_class}({identifier})'.format(_class=type(self).__name__, identifier=self.identifier()))
+        return str('<{_class}({identifier})>'.format(_class=type(self).__name__, identifier=self.identifier()))
 
 
 class Kill(_WorkflowEntity):

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -640,8 +640,8 @@ class WorkflowApp(XMLSerializable):
             job_xml_files=job_xml_files,
             configuration=configuration
         )
-        self.__credentials = credentials or []
-        self.__actions = copy.deepcopy(actions)
+        self.__credentials = copy.deepcopy(credentials) or []
+        self.__actions = copy.deepcopy(actions) or []
         self.__validate()
 
     def __validate(self):  # type () -> None

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -607,9 +607,9 @@ class Action(_WorkflowEntity):
         }
         if self.__credential:
             attributes['cred'] = self.__credential
-        if self.__retry_max:
+        if self.__retry_max is not None:
             attributes['retry-max'] = str(self.__retry_max)
-        if self.__retry_interval:
+        if self.__retry_interval is not None:
             attributes['retry-interval'] = str(self.__retry_interval)
         with tag(self.xml_tag(), **attributes):
             self.__action._xml(doc, tag, text)

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -547,6 +547,12 @@ class _WorkflowEntity(typing.Iterable):
             for action in self.__on_error:
                 yield action
 
+    def __bool__(self):  # type: () -> bool
+        return bool(list(self))
+
+    def __nonzero__(self):  # type: () -> bool
+        return self.__bool__()
+
     def __repr__(self):
         # type: () -> str
         return str('{_class}({identifier})'.format(_class=type(self).__name__, identifier=self.identifier()))

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -2,10 +2,11 @@
 # Use of this source code is governed by a MIT-style license that can be found in the LICENSE file.
 from __future__ import unicode_literals
 import abc
+import collections
 import datetime
 import re
 import string  # pylint: disable=deprecated-module
-import warnings
+import uuid
 
 import enum
 import typing  # pylint: disable=unused-import
@@ -494,6 +495,124 @@ class CoordinatorApp(XMLSerializable):
         return doc
 
 
+class _WorkflowEntity(typing.Iterable):
+    """An abstract object representing an Oozie workflow action that can be serialized to XML."""
+    # pylint: disable=abstract-method
+
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(
+            self,
+            xml_tag,       # typing.Text
+            name=None,     # type: typing.Optional[typing.Text]
+            on_error=None  # type: typing.Optional[_WorkflowEntity]
+    ):
+        # type: (...) -> None
+        self.xml_tag = xml_tag
+        self.__name = name
+        self.__on_error = on_error
+        self.__uid = uuid.uuid4().hex[:8]
+        self.__identifier = self.create_identifier(xml_tag)
+
+    def create_identifier(self, xml_tag):
+        # type: (typing.Text) -> typing.Text
+        identifier = None
+        if self.__name:
+            identifier = '{tag}-{name}'.format(tag=xml_tag, name=self.__name)
+        else:
+            identifier = '{tag}-{uid}'.format(tag=xml_tag, uid=self.__uid)
+        return validate_xml_id(identifier)
+
+    def identifier(self):
+        # type: () -> typing.Text
+        return self.__identifier
+
+    def _xml_and_get_on_error(self, doc, tag, text, on_next, on_error):
+        if self.__on_error:
+            self.__on_error._xml(doc, tag, text, on_next, on_error)
+        return self.__on_error.identifier() if self.__on_error else (
+            on_error if on_error else on_next
+        )
+
+    @abc.abstractmethod
+    def _xml(self, doc, tag, text, on_next, on_error):
+        # type: (yattag.doc.Doc, yattag.doc.Doc.tag, yattag.doc.Doc.text, typing.Text, typing.Text) -> yattag.doc.Doc
+        raise NotImplementedError()
+
+    def __iter__(self):
+        yield self
+        if self.__on_error:
+            for action in self.__on_error:
+                yield action
+
+    def __repr__(self):
+        return '{_class}({identifier})'.format(_class=type(self).__name__, identifier=self.identifier())
+
+
+class Kill(_WorkflowEntity):
+    """Workflow graph terminal node(s) to end upon to indicate failure."""
+
+    def __init__(self, message, name=None):
+        # type: (typing.Text, typing.Optional[typing.Text]) -> None
+        super(Kill, self).__init__(xml_tag='kill', name=name)
+        self.message = message
+
+    def _xml(self, doc, tag, text, on_next, on_error):
+        # type: (yattag.doc.Doc, yattag.doc.Doc.tag, yattag.doc.Doc.text, typing.Text, typing.Text) -> yattag.doc.Doc
+        with tag(self.xml_tag, name=self.identifier()):
+            with tag('message'):
+                doc.text(self.message)
+        return doc
+
+
+ConcreteAction = typing.Union[Shell, SubWorkflow, Email]
+
+
+class Action(_WorkflowEntity):
+    """Workflow action nodes carrying concrete actions that perform an action."""
+
+    def __init__(
+            self,
+            action,               # type: ConcreteAction
+            name=None,            # type: typing.Optional[typing.Text]
+            credential=None,      # type: typing.Optional[typing.Text]
+            retry_max=None,       # type: typing.Optional[int]
+            retry_interval=None,  # type: typing.Optional[int]
+            on_error=None         # type: typing.Optional[_WorkflowEntity]
+    ):
+        # type: (...) -> None
+        super(Action, self).__init__(xml_tag='action', name=name, on_error=on_error)
+
+        # XML-document-related values
+        self.__action = action
+        self.__credential = credential
+        self.__retry_max = retry_max
+        self.__retry_interval = retry_interval
+
+    def credential(self):
+        return self.__credential
+
+    def _xml(self, doc, tag, text, on_next, on_error):
+        # type: (yattag.doc.Doc, yattag.doc.Doc.tag, yattag.doc.Doc.text, typing.Text, typing.Text) -> yattag.doc.Doc
+        _on_error = self._xml_and_get_on_error(doc, tag, text, on_next, on_error)
+
+        attributes = {
+            'name': self.identifier(),
+        }
+        if self.__credential:
+            attributes['cred'] = self.__credential
+        if self.__retry_max:
+            attributes['retry-max'] = str(self.__retry_max)
+        if self.__retry_interval:
+            attributes['retry-interval'] = str(self.__retry_interval)
+        with tag(self.xml_tag, **attributes):
+            self.__action._xml(doc, tag, text)
+            doc.stag('ok', to=on_next)
+            doc.stag('error', to=_on_error)
+
+        return doc
+
+
 class WorkflowApp(XMLSerializable):
 
     def __init__(
@@ -505,35 +624,68 @@ class WorkflowApp(XMLSerializable):
             job_tracker=None,             # type: typing.Optional[typing.Text]
             name_node=None,               # type: typing.Optional[typing.Text]
             job_xml_files=None,           # type: typing.Optional[JobXmlFilesType]
+            actions=None,                 # type: typing.Optional[_WorkflowEntity]
     ):
         # type: (...) -> None
         XMLSerializable.__init__(self, 'workflow-app')
-        self.name = validate_xml_name(name)
 
-        self.parameters = Parameters(parameters)
-        self.global_configuration = GlobalConfiguration(
+        # XML-document-related values
+        self.__name = validate_xml_name(name)
+        self.__parameters = Parameters(parameters)
+        self.__global_configuration = GlobalConfiguration(
             job_tracker=job_tracker,
             name_node=name_node,
             job_xml_files=job_xml_files,
             configuration=configuration
         )
-        self.credentials = credentials
+        self.__credentials = credentials or []
+        self.__actions = actions
+        self.__validate()
+
+    def __validate(self):
+        # Parse actions for attributes
+        action_identifiers = []
+        credentials_needed = set()
+
+        def _parse_action(action):
+            action_identifiers.append(action.identifier())
+            if hasattr(action, 'credential'):
+                credential = action.credential()
+                if credential:
+                    credentials_needed.add(credential)
+
+        if self.__actions:
+            for action in set(self.__actions):
+                _parse_action(action)
+
+        # Verify that all needed credentials are defined
+        credentials_provided = frozenset([cred.name for cred in self.__credentials])
+        assert credentials_needed <= credentials_provided, (
+            'Missing credentials: %s' % ', '.join(credentials_needed - credentials_provided)
+        )
+
+        # Verify that no duplicate identifiers are used
+        duplicate_identifiers = tuple(
+            item for item, count in collections.Counter(action_identifiers).items() if count > 1)
+        assert not duplicate_identifiers, 'Name(s) reused: %s' % ', '.join(sorted(duplicate_identifiers))
 
     def _xml(self, doc, tag, text):
-        with tag(self.xml_tag, name=self.name, xmlns="uri:oozie:workflow:0.5"):
+        with tag(self.xml_tag, name=self.__name, xmlns="uri:oozie:workflow:0.5"):
 
             # Preamble
-            if self.parameters:
-                self.parameters._xml(doc, tag, text)
-            if self.global_configuration:
-                self.global_configuration._xml(doc, tag, text)
-            if self.credentials:
+            if self.__parameters:
+                self.__parameters._xml(doc, tag, text)
+            if self.__global_configuration:
+                self.__global_configuration._xml(doc, tag, text)
+            if self.__credentials:
                 with tag('credentials'):
-                    for credential in self.credentials:
+                    for credential in self.__credentials:
                         credential._xml(doc, tag, text)
 
-            doc.stag('start', to='end')
-            warnings.warn("This will contain more than just a start and end tag in the future", FutureWarning)
+            # Create a serial collection of workflow entities to hold actions
+            doc.stag('start', to=self.__actions.identifier() if self.__actions else 'end')
+            if self.__actions:
+                self.__actions._xml(doc, tag, text, on_next='end', on_error=None)
             doc.stag('end', name='end')
 
         return doc

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -509,7 +509,7 @@ class _WorkflowEntity(typing.Iterable):
             on_error=None  # type: typing.Optional[_WorkflowEntity]
     ):
         # type: (...) -> None
-        self.xml_tag = xml_tag
+        self.__xml_tag = xml_tag
         self.__on_error = copy.deepcopy(on_error)
         if name:
             self.__identifier = '{tag}-{name}'.format(tag=xml_tag, name=name)
@@ -519,6 +519,10 @@ class _WorkflowEntity(typing.Iterable):
     def identifier(self):
         # type: () -> typing.Text
         return self.__identifier
+
+    def xml_tag(self):
+        # type: () -> typing.Text
+        return self.__xml_tag
 
     def _xml_and_get_on_error(self, doc, tag, text, on_next, on_error):
         # type: (yattag.doc.Doc, yattag.doc.Doc.tag, yattag.doc.Doc.text, typing.Text, typing.Text) -> yattag.doc.Doc
@@ -560,7 +564,7 @@ class Kill(_WorkflowEntity):
 
     def _xml(self, doc, tag, text, on_next, on_error):
         # type: (yattag.doc.Doc, yattag.doc.Doc.tag, yattag.doc.Doc.text, typing.Text, typing.Text) -> yattag.doc.Doc
-        with tag(self.xml_tag, name=self.identifier()):
+        with tag(self.xml_tag(), name=self.identifier()):
             with tag('message'):
                 doc.text(self.message)
         return doc
@@ -607,7 +611,7 @@ class Action(_WorkflowEntity):
             attributes['retry-max'] = str(self.__retry_max)
         if self.__retry_interval:
             attributes['retry-interval'] = str(self.__retry_interval)
-        with tag(self.xml_tag, **attributes):
+        with tag(self.xml_tag(), **attributes):
             self.__action._xml(doc, tag, text)
             doc.stag('ok', to=on_next)
             doc.stag('error', to=_on_error)

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -510,19 +510,11 @@ class _WorkflowEntity(typing.Iterable):
     ):
         # type: (...) -> None
         self.xml_tag = xml_tag
-        self.__name = name
         self.__on_error = copy.deepcopy(on_error)
-        self.__uid = uuid.uuid4().hex[:8]
-        self.__identifier = self.create_identifier(xml_tag)
-
-    def create_identifier(self, xml_tag):
-        # type: (typing.Text) -> typing.Text
-        identifier = None
-        if self.__name:
-            identifier = '{tag}-{name}'.format(tag=xml_tag, name=self.__name)
+        if name:
+            self.__identifier = '{tag}-{name}'.format(tag=xml_tag, name=name)
         else:
-            identifier = '{tag}-{uid}'.format(tag=xml_tag, uid=self.__uid)
-        return validate_xml_id(identifier)
+            self.__identifier = '{tag}-{uid}'.format(tag=xml_tag, uid=uuid.uuid4().hex[:8])
 
     def identifier(self):
         # type: () -> typing.Text

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -645,7 +645,7 @@ class WorkflowApp(XMLSerializable):
             configuration=configuration
         )
         self.__credentials = copy.deepcopy(credentials) or []
-        self.__entities = copy.deepcopy(entities) or []
+        self.__entities = copy.deepcopy(entities) or None
         self.__validate()
 
     def __validate(self):  # type () -> None

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals
 import abc
 import collections
+import copy
 import datetime
 import re
 import string  # pylint: disable=deprecated-module
@@ -510,7 +511,7 @@ class _WorkflowEntity(typing.Iterable):
         # type: (...) -> None
         self.xml_tag = xml_tag
         self.__name = name
-        self.__on_error = on_error
+        self.__on_error = copy.deepcopy(on_error)
         self.__uid = uuid.uuid4().hex[:8]
         self.__identifier = self.create_identifier(xml_tag)
 
@@ -648,7 +649,7 @@ class WorkflowApp(XMLSerializable):
             configuration=configuration
         )
         self.__credentials = credentials or []
-        self.__actions = actions
+        self.__actions = copy.deepcopy(actions)
         self.__validate()
 
     def __validate(self):  # type () -> None

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -553,8 +553,7 @@ class _WorkflowEntity(typing.Iterable):
     def __nonzero__(self):  # type: () -> bool
         return self.__bool__()
 
-    def __repr__(self):
-        # type: () -> str
+    def __repr__(self):  # type: () -> str
         return str('{_class}({identifier})'.format(_class=type(self).__name__, identifier=self.identifier()))
 
 

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -528,6 +528,7 @@ class _WorkflowEntity(typing.Iterable):
         return self.__identifier
 
     def _xml_and_get_on_error(self, doc, tag, text, on_next, on_error):
+        # type: (yattag.doc.Doc, yattag.doc.Doc.tag, yattag.doc.Doc.text, typing.Text, typing.Text) -> yattag.doc.Doc
         if self.__on_error:
             self.__on_error._xml(doc, tag, text, on_next, on_error)
         return self.__on_error.identifier() if self.__on_error else (
@@ -540,13 +541,15 @@ class _WorkflowEntity(typing.Iterable):
         raise NotImplementedError()
 
     def __iter__(self):
+        # type: () -> typing.Generator[_WorkflowEntity, None, None]
         yield self
         if self.__on_error:
             for action in self.__on_error:
                 yield action
 
     def __repr__(self):
-        return '{_class}({identifier})'.format(_class=type(self).__name__, identifier=self.identifier())
+        # type: () -> str
+        return str('{_class}({identifier})'.format(_class=type(self).__name__, identifier=self.identifier()))
 
 
 class Kill(_WorkflowEntity):
@@ -590,6 +593,7 @@ class Action(_WorkflowEntity):
         self.__retry_interval = retry_interval
 
     def credential(self):
+        # type: () -> typing.Optional[typing.Text]
         return self.__credential
 
     def _xml(self, doc, tag, text, on_next, on_error):
@@ -642,8 +646,7 @@ class WorkflowApp(XMLSerializable):
         self.__actions = actions
         self.__validate()
 
-    def __validate(self):
-        # Parse actions for attributes
+    def __validate(self):  # type () -> None
         action_identifiers = []
         credentials_needed = set()
 
@@ -654,6 +657,7 @@ class WorkflowApp(XMLSerializable):
                 if credential:
                     credentials_needed.add(credential)
 
+        # Parse actions for attributes
         if self.__actions:
             for action in set(self.__actions):
                 _parse_action(action)
@@ -670,6 +674,7 @@ class WorkflowApp(XMLSerializable):
         assert not duplicate_identifiers, 'Name(s) reused: %s' % ', '.join(sorted(duplicate_identifiers))
 
     def _xml(self, doc, tag, text):
+        # type: (yattag.doc.Doc, yattag.doc.Doc.tag, yattag.doc.Doc.text) -> yattag.doc.Doc
         with tag(self.xml_tag, name=self.__name, xmlns="uri:oozie:workflow:0.5"):
 
             # Preamble

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setuplib.setup(
             'requests-mock',
             'shopify_python==0.2.2',
             'xmltodict',
+            'pywebhdfs>=0.4.1',
         ],
     },
     license="MIT",

--- a/tests/pyoozie/test_interactive.py
+++ b/tests/pyoozie/test_interactive.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import datetime
+import os
+
+import pyoozie
+import pytest
+import pywebhdfs.webhdfs
+import six
+
+
+@pytest.mark.skipif(not bool(os.environ.get(str('INTERACTIVE'))), reason='Requires INTERACTIVE=1 env var')
+def test_pyoozie_typical_use_case():
+
+    # Configure
+    workflow_path = '/user/oozie/test_workflow.xml'
+    coord_path = '/user/oozie/test_coordinator.xml'
+    hadoop_user_name = 'root'
+    name_node = 'hdfs://hdfs-namenode:9000'
+    job_tracker = 'resourcemanager:8032'
+
+    configuration = {
+        'oozie.launcher.mapreduce.job.ubertask.enable': 'false',
+    }
+
+    # Create XML
+    workflow_xml = pyoozie.WorkflowApp(
+        name='integration',
+        entities=pyoozie.Action(
+            action=pyoozie.Shell(
+                exec_command="echo",
+                arguments="test",
+                name_node=name_node,
+                job_tracker=job_tracker,
+                configuration=configuration,
+            )
+        )
+    ).xml(indent=True)
+    print('Created workflow XML')
+    print(workflow_xml.decode('utf-8'))
+
+    coord_xml = pyoozie.CoordinatorApp(
+        name='integration',
+        workflow_app_path=workflow_path,
+        frequency=5,
+        start=datetime.datetime.now(),
+        end=datetime.datetime(2115, 1, 1, 10, 56),
+        concurrency=1,
+        timeout=5,
+        execution_order=pyoozie.ExecutionOrder.LAST_ONLY,
+    ).xml(indent=True)
+    print('Created coordinator XML')
+    print(coord_xml.decode('utf-8'))
+
+    # Store on HDFS
+    hdfs_client = pywebhdfs.webhdfs.PyWebHdfsClient(host='localhost', port='14000', user_name=hadoop_user_name)
+    for path, data in {workflow_path: workflow_xml, coord_path: coord_xml}.items():
+        hdfs_client.create_file(path=path, file_data=data, overwrite=True)
+        status = hdfs_client.get_file_dir_status(path)
+        assert status and status['FileStatus']['type'] == 'FILE'
+        print('Wrote to HDFS %s' % path)
+
+    # Submit coordinator to Oozie
+    oozie_client = pyoozie.OozieClient(
+        url='http://localhost:11000',
+        user=hadoop_user_name,
+    )
+    coord_config = {
+        'user.name': hadoop_user_name,
+        'custom.config': '😢',
+    }
+    print('Submitting coordinator to Oozie')
+    coordinator = oozie_client.jobs_submit_coordinator(
+        coord_path,
+        coord_config,
+    )
+
+    # Test that all is well
+    print('Coordinator %s created' % coordinator.coordJobId)
+    assert coordinator.status.is_active
+
+    # Prompt
+    six.moves.input("Press enter to delete coordinator")
+    print('Deleting %s' % coordinator.coordJobId)
+    assert oozie_client.job_coordinator_kill(coordinator.coordJobId)

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -509,12 +509,45 @@ def test_workflow_action(request):
     actions = tags.Action(
         name='action-name',
         action=tags.Shell(exec_command='echo', arguments=['build']),
+    )
+    assert len(set(actions)) == 1
+    assert bool(actions)
+
+    workflow_app = tags.WorkflowApp(
+        name='descriptive-name',
+        job_tracker='job-tracker',
+        name_node='name-node',
+        actions=actions
+    )
+    assert_workflow(request, workflow_app, """
+<workflow-app xmlns="uri:oozie:workflow:0.5" name="descriptive-name">
+    <global>
+        <job-tracker>job-tracker</job-tracker>
+        <name-node>name-node</name-node>
+    </global>
+    <start to="action-action-name" />
+    <action name="action-action-name">
+        <shell xmlns="uri:oozie:shell-action:0.3">
+            <exec>echo</exec>
+            <argument>build</argument>
+        </shell>
+        <ok to="end" />
+        <error to="end" />
+    </action>
+    <end name="end" />
+</workflow-app>
+""")
+
+    actions = tags.Action(
+        name='action-name',
+        action=tags.Shell(exec_command='echo', arguments=['build']),
         credential='my-hcat-creds',
         retry_max=10,
         retry_interval=20,
         on_error=tags.Kill(name='error', message='A bad thing happened'),
     )
     assert len(set(actions)) == 2
+    assert bool(actions)
 
     workflow_app = tags.WorkflowApp(
         name='descriptive-name',

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -506,18 +506,18 @@ def test_workflow_app(request):
 
 
 def test_workflow_action(request):
-    actions = tags.Action(
+    entities = tags.Action(
         name='action-name',
         action=tags.Shell(exec_command='echo', arguments=['build']),
     )
-    assert len(set(actions)) == 1
-    assert bool(actions)
+    assert len(set(entities)) == 1
+    assert bool(entities)
 
     workflow_app = tags.WorkflowApp(
         name='descriptive-name',
         job_tracker='job-tracker',
         name_node='name-node',
-        actions=actions
+        entities=entities
     )
     assert_workflow(request, workflow_app, """
 <workflow-app xmlns="uri:oozie:workflow:0.5" name="descriptive-name">
@@ -538,7 +538,7 @@ def test_workflow_action(request):
 </workflow-app>
 """)
 
-    actions = tags.Action(
+    entities = tags.Action(
         name='action-name',
         action=tags.Shell(exec_command='echo', arguments=['build']),
         credential='my-hcat-creds',
@@ -546,8 +546,8 @@ def test_workflow_action(request):
         retry_interval=20,
         on_error=tags.Kill(name='error', message='A bad thing happened'),
     )
-    assert len(set(actions)) == 2
-    assert bool(actions)
+    assert len(set(entities)) == 2
+    assert bool(entities)
 
     workflow_app = tags.WorkflowApp(
         name='descriptive-name',
@@ -557,7 +557,7 @@ def test_workflow_action(request):
             {'cred_name': 'cred_value'},
             credential_name='my-hcat-creds',
             credential_type='hcat')],
-        actions=actions
+        entities=entities
     )
     assert_workflow(request, workflow_app, """
 <workflow-app xmlns="uri:oozie:workflow:0.5" name="descriptive-name">
@@ -596,7 +596,7 @@ def test_workflow_action_without_credential():
             name='descriptive-name',
             job_tracker='job-tracker',
             name_node='name-node',
-            actions=tags.Action(
+            entities=tags.Action(
                 name='action-name',
                 action=tags.Shell(exec_command='echo', arguments=['build']),
                 credential='my-hcat-creds',
@@ -613,7 +613,7 @@ def test_workflow_with_reused_identifier():
             name='descriptive-name',
             job_tracker='job-tracker',
             name_node='name-node',
-            actions=tags.Action(
+            entities=tags.Action(
                 name='build', action=tags.Shell(exec_command='echo', arguments=['build']),
                 on_error=tags.Action(name='build', action=tags.Shell(exec_command='echo', arguments=['error']))
             )


### PR DESCRIPTION
This PR adds to the `WorkflowApp` class the ability to serialize to XML [action](https://oozie.apache.org/docs/4.1.0/WorkflowFunctionalSpec.html#a3.2_Workflow_Action_Nodes) and [kill](https://oozie.apache.org/docs/4.1.0/WorkflowFunctionalSpec.html#a3.1.3_Kill_Control_Node) nodes using the [`oozie-workflow-0.5.xsd` schema](https://github.com/apache/oozie/blob/master/client/src/main/resources/oozie-workflow-0.5.xsd).

### Implementation
This PR implements:
  - An abstract `_WorkflowEntity` class to serve as the base type for these and other structures that will be exposed to users to allow them to define a workflow which features:
    - An optional `on_error` parameter which allows one to specify a `_WorkflowEntity` to transition to if an error occurs
    - An optional `name` to help document identifiers in the XML (otherwise a uid is used)
  - A `Kill` `_WorkflowEntity` which if transitioned to kills a workflow and emits a message
  - An `Action ` `_WorkflowEntity` which wraps a `ConcreteAction` (e.g. execute a shell command, subworkflow, or email) which
    - Can specify credentials that are to be used by a concrete action
    - Can specify action retry semantics

This PR also adjusts `WorkflowApp` to validate that:
  - All credentials referred to by actions are supplied in the constructor
  - No duplicate identifiers are present in the actions provided (an Oozie logic error)

This PR enables the ability to define collections of actions that can be executed serially/in parallel (https://github.com/Shopify/pyoozie/pull/50).

🎩 'd by starting a local [Oozie 4.1.0 instance](https://github.com/cfournie/docker-hadoop/tree/oozie/2.6.0) using `docker-compose up -d` and manipulating `tests/pyoozie/test_interactive.py` to specify different values.

#### Notes
This PR is one of several that are intended to add an API to define forking/joining workflows with error-handling prototyped in https://github.com/Shopify/pyoozie/pull/26.