### PR TITLE
Add decision action

### DIFF
--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -22,6 +22,7 @@ from pyoozie.tags import Action
 from pyoozie.tags import Configuration
 from pyoozie.tags import CoordinatorApp
 from pyoozie.tags import Credential
+from pyoozie.tags import Decision
 from pyoozie.tags import Email
 from pyoozie.tags import ExecutionOrder
 from pyoozie.tags import EXEC_FIFO

--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -66,6 +66,7 @@ __all__ = (
     'Configuration',
     'CoordinatorApp',
     'Credential',
+    'Decision',
     'Email',
     'ExecutionOrder',
     'EXEC_FIFO',

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -636,8 +636,8 @@ class Decision(_AbstractWorkflowEntity):
         super(Decision, self).__init__(xml_tag='decision', name=name, on_error=on_error)
         assert default, 'A default must be supplied'
         assert choices, 'At least one choice required'
-        self.__default = default
-        self.__choices = choices
+        self.__default = copy.deepcopy(default)
+        self.__choices = copy.deepcopy(choices)
 
     def _xml(self, doc, tag, text, on_next, on_error):
         # type: (yattag.doc.Doc, yattag.doc.Doc.tag, yattag.doc.Doc.text, typing.Text, typing.Text) -> yattag.doc.Doc

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -627,10 +627,10 @@ class Decision(_AbstractWorkflowEntity):
 
     def __init__(
             self,
-            default,        # type: _WorkflowEntity
-            choices,        # type: typing.Dict[typing.Text, _WorkflowEntity]
+            default,        # type: _AbstractWorkflowEntity
+            choices,        # type: typing.Dict[typing.Text, _AbstractWorkflowEntity]
             name=None,      # type: typing.Optional[typing.Text]
-            on_error=None,  # type: typing.Optional[_WorkflowEntity]
+            on_error=None,  # type: typing.Optional[_AbstractWorkflowEntity]
     ):
         # type: (...) -> None
         super(Decision, self).__init__(xml_tag='decision', name=name, on_error=on_error)
@@ -659,7 +659,7 @@ class Decision(_AbstractWorkflowEntity):
         return doc
 
     def __iter__(self):
-        # type: () -> typing.Generator[_WorkflowEntity, None, None]
+        # type: () -> typing.Generator[_AbstractWorkflowEntity, None, None]
         for action in self.__choices.values():
             yield action
         yield self.__default

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -622,6 +622,51 @@ class Action(_AbstractWorkflowEntity):
         return doc
 
 
+class Decision(_AbstractWorkflowEntity):
+    """Node specifying a switch/case."""
+
+    def __init__(
+            self,
+            default,        # type: _WorkflowEntity
+            choices,        # type: typing.Dict[typing.Text, _WorkflowEntity]
+            name=None,      # type: typing.Optional[typing.Text]
+            on_error=None,  # type: typing.Optional[_WorkflowEntity]
+    ):
+        # type: (...) -> None
+        super(Decision, self).__init__(xml_tag='decision', name=name, on_error=on_error)
+        assert default, 'A default must be supplied'
+        assert choices, 'At least one choice required'
+        self.__default = default
+        self.__choices = choices
+
+    def _xml(self, doc, tag, text, on_next, on_error):
+        # type: (yattag.doc.Doc, yattag.doc.Doc.tag, yattag.doc.Doc.text, typing.Text, typing.Text) -> yattag.doc.Doc
+        _on_error = self._xml_and_get_on_error(doc, tag, text, on_next, on_error)
+
+        # Write switch/case
+        with tag(self.xml_tag, name=self.identifier()):
+            with tag('switch'):
+                for case, dest in self.__choices.items():
+                    with tag('case', to=dest.identifier()):
+                        doc.text(case)
+                doc.stag('default', to=self.__default.identifier())
+
+        # Write contained actions
+        self.__default._xml(doc, tag, text, on_next, _on_error)
+        for choice in self.__choices.values():
+            choice._xml(doc, tag, text, on_next, _on_error)
+
+        return doc
+
+    def __iter__(self):
+        # type: () -> typing.Generator[_WorkflowEntity, None, None]
+        for action in self.__choices.values():
+            yield action
+        yield self.__default
+        for action in super(Decision, self).__iter__():
+            yield action
+
+
 class Serial(_AbstractWorkflowEntity):
     """Sequence of entities to execute (implemented by chaining entities and 'OK' transitions)"""
 

--- a/pyoozie/tags.py
+++ b/pyoozie/tags.py
@@ -644,7 +644,7 @@ class Decision(_AbstractWorkflowEntity):
         _on_error = self._xml_and_get_on_error(doc, tag, text, on_next, on_error)
 
         # Write switch/case
-        with tag(self.xml_tag, name=self.identifier()):
+        with tag(self.xml_tag(), name=self.identifier()):
             with tag('switch'):
                 for case, dest in self.__choices.items():
                     with tag('case', to=dest.identifier()):

--- a/tests/pyoozie/test_tags.py
+++ b/tests/pyoozie/test_tags.py
@@ -835,7 +835,7 @@ def test_workflow_app_inherit_parent_error(request):
     app.assert_node("/action[@name='action-error']/ok", to='kill-error')
 
 
-def test_workflow_app_empty_decision_actions():
+def test_workflow_app_empty_decision_entities():
     with pytest.raises(AssertionError) as assertion_info:
         tags.Decision(
             default=None,
@@ -861,8 +861,8 @@ def test_workflow_app_empty_decision_actions():
     assert str(assertion_info.value) == 'At least one choice required'
 
 
-def test_workflow_app_decision_actions(request):
-    actions = tags.Decision(
+def test_workflow_app_decision_entities(request):
+    entities = tags.Decision(
         default=tags.Action(tags.Shell(exec_command='echo', arguments=['default'])),
         choices={
             '${wf:lastErrorNode() eq null}': tags.Action(
@@ -873,13 +873,13 @@ def test_workflow_app_decision_actions(request):
             tags.Kill('A bad thing happened')
         )
     )
-    assert len(set(actions)) == 5
+    assert len(set(entities)) == 5
 
     workflow_app = tags.WorkflowApp(
         name='descriptive-name',
         job_tracker='job-tracker',
         name_node='name-node',
-        actions=actions
+        entities=entities
     )
     assert_workflow(request, workflow_app, """
 <workflow-app xmlns="uri:oozie:workflow:0.5" name="descriptive-name">


### PR DESCRIPTION
This PR extends the available collections for Oozie workflow actions to include [`decision` nodes](https://oozie.apache.org/docs/4.1.0/WorkflowFunctionalSpec.html#a3.1.4_Decision_Control_Node) (using the [`oozie-workflow-0.5.xsd` schema](https://github.com/apache/oozie/blob/master/client/src/main/resources/oozie-workflow-0.5.xsd)) with error handling definable using an `on_error` parameter.

### Discussion
This PR implements decision nodes and error handling such that we can accomplish one crucial execution pattern: checkpointing.

When a collection of actions are being executed in parallel and one of them transitions to a kill node, that kills the entire workflow (parallel actions and all). The other parallel actions may complete successfully, but if a single one transitions to kill it interrupts them.

| Without checkpoint | With checkpoint |
| --- | --- |
| ![graph4](https://user-images.githubusercontent.com/49264/26985530-d710c1fa-4d11-11e7-8495-229944a0b1af.png) | ![graph3](https://user-images.githubusercontent.com/49264/26985367-3c64ee92-4d11-11e7-9e50-86680a98b28e.png) |

Using the checkpointing pattern, instead of directly transition to kill within a fork, we short-circuit and transition to the join node (allowing other parallel actions to continue) and after that join we can add a decision node to check whether any previous task has encountered an error and then transition to a kill node.

#### Notes
This PR is one of several that are intended to add an API to define forking/joining workflows with error-handling prototyped in https://github.com/Shopify/pyoozie/pull/26.