### PR TITLE
Change how we specify environment markers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ clean:
 		rm -fr *.egg-info
 
 install:
-		pip install -e ".[test,testpy3]"
+		pip install -e ".[test]"
 		test -d lib || mkdir lib
 		test -f lib/oozie-client-4.1.0.jar || \
 			curl http://central.maven.org/maven2/org/apache/oozie/oozie-client/4.1.0/oozie-client-4.1.0.jar -o lib/oozie-client-4.1.0.jar

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ clean:
 		rm -fr *.egg-info
 
 install:
-		pip install -e ".[test]"
+		pip install -e ".[test,testpy3]"
 		test -d lib || mkdir lib
 		test -f lib/oozie-client-4.1.0.jar || \
 			curl http://central.maven.org/maven2/org/apache/oozie/oozie-client/4.1.0/oozie-client-4.1.0.jar -o lib/oozie-client-4.1.0.jar

--- a/pylintrc
+++ b/pylintrc
@@ -49,7 +49,8 @@ load-plugins=shopify_python
 # fixme; we're in-development, so we need some of these
 disable=missing-docstring,too-few-public-methods,too-many-instance-attributes,too-many-arguments,
  protected-access,invalid-name,redefined-outer-name,no-self-use,too-many-public-methods,too-many-lines,
- duplicate-code,fixme
+ duplicate-code,fixme,no-else-return,not-callable,len-as-condition,cond-expr,useless-super-delegation,
+ super-init-not-called
 
 # Increase max except nodes because we often have a pattern of
 # record stats, log, and then re-raise when handling HTTP exceptions

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setuplib.setup(
             'pytest-randomly',
             'pytest>=2.7',
             'requests-mock',
-            'shopify_python==0.2.2',
+            'shopify_python==0.4.1',
             'xmltodict',
             'pywebhdfs>=0.4.1',
         ],

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setuplib.setup(
             'autopep8',
             'flake8',
             'mock',
-            'mypy; python_version >= "3.3"',
             'pycodestyle == 2.2.0',
             'pylint>=1.6.5,<1.7',
             'pytest-cov',
@@ -54,6 +53,9 @@ setuplib.setup(
             'xmltodict',
             'pywebhdfs>=0.4.1',
         ],
+        'testpy3: python_version >= "3.3"': [
+            'mypy',
+        ]
     },
     license="MIT",
     keywords=['oozie'],

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setuplib.setup(
             'flake8',
             'mock',
             'pycodestyle == 2.2.0',
-            'pylint>=1.6.5,<1.7',
+            'pylint>=1.7.1,<1.8',
             'pytest-cov',
             'pytest-randomly',
             'pytest>=2.7',

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setuplib.setup(
             'xmltodict',
             'pywebhdfs>=0.4.1',
         ],
-        'testpy3: python_version >= "3.3"': [
+        'test: python_version >= "3.3"': [
             'mypy',
         ]
     },


### PR DESCRIPTION
The latest version of setuptools (36.2.0) introduced https://github.com/pypa/setuptools/pull/1085, which disallows the manner in which we were specifying environment markers, which broke a variety of env marker usages https://github.com/pypa/setuptools/issues/1087.

This PR properly specifies env markers.