### PR TITLE
Increase version number to 0.0.1

### DIFF
--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -38,7 +38,7 @@ from pyoozie.tags import validate_xml_name
 from pyoozie.tags import WorkflowApp
 
 
-__version__ = '0.0.0'
+__version__ = '0.0.1'
 
 __all__ = (
     # builder


### PR DESCRIPTION
Let's cut a feature release that includes these feature-adding PRs:
  - Add ability to update a coordinator's definition https://github.com/Shopify/pyoozie/pull/42
  - Add missing is_active tags to some statuses https://github.com/Shopify/pyoozie/pull/44
  - Leave conf None if not provided https://github.com/Shopify/pyoozie/pull/47
  - Add test utilities https://github.com/Shopify/pyoozie/pull/45
  - Add basic workflow generation https://github.com/Shopify/pyoozie/pull/49

And the following bugfixes:
  - Change how we specify environment markers https://github.com/Shopify/pyoozie/pull/53

This also includes other cleanup PRs including:
  - Replace pep8 with pycodestyle https://github.com/Shopify/pyoozie/pull/39
  - Pin Pylint in requirements https://github.com/Shopify/pyoozie/pull/43
  - Fix flaky XML comparison https://github.com/Shopify/pyoozie/pull/48