### PR TITLE
Suspended coordinators api

### DIFF
--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -38,7 +38,7 @@ from pyoozie.tags import validate_xml_name
 from pyoozie.tags import WorkflowApp
 
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'
 
 __all__ = (
     # builder

--- a/pyoozie/client.py
+++ b/pyoozie/client.py
@@ -282,6 +282,9 @@ class OozieClient(object):
     def jobs_all_running_coordinators(self, user=None):
         return self._jobs_query(model.ArtifactType.Coordinator, status=model.CoordinatorStatus.running(), user=user)
 
+    def jobs_all_suspended_coordinators(self, user=None):
+        return self._jobs_query(model.ArtifactType.Coordinator, status=model.CoordinatorStatus.suspended(), user=user)
+
     def jobs_running_coordinators(self, name, user=None):
         return self._jobs_query(
             model.ArtifactType.Coordinator, name=name, status=model.CoordinatorStatus.running(), user=user)

--- a/tests/pyoozie/test_client.py
+++ b/tests/pyoozie/test_client.py
@@ -550,6 +550,17 @@ class TestOozieClientJobsQuery(object):
             api.jobs_all_running_coordinators(user='john_doe')
             mock_query.assert_called_with(model.ArtifactType.Coordinator, user='john_doe', status=expected_statuses)
 
+    def test_jobs_all_suspended_coordinators(self, api, sample_coordinator_suspended):
+        expected_statuses = model.CoordinatorStatus.suspended()
+        with mock.patch.object(api, '_jobs_query') as mock_query:
+            mock_query.return_value = [sample_coordinator_suspended]
+
+            api.jobs_all_suspended_coordinators()
+            mock_query.assert_called_with(model.ArtifactType.Coordinator, user=None, status=expected_statuses)
+
+            api.jobs_all_suspended_coordinators(user='john_doe')
+            mock_query.assert_called_with(model.ArtifactType.Coordinator, user='john_doe', status=expected_statuses)
+
     def test_jobs_running_coordinators(self, api, sample_coordinator_running):
         expected_statuses = model.CoordinatorStatus.running()
         with mock.patch.object(api, '_jobs_query') as mock_query:


### PR DESCRIPTION
Added a public suspended coordinators api, needed for: https://github.com/Shopify/dogpound/pull/50