### PR TITLE
Add twine to a user's env and talk about releasing from master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ clean:
 		rm -fr *.egg-info
 
 install:
-		pip install -e ".[test]"
+		pip install -e ".[test,deploy]"
 		test -d lib || mkdir lib
 		test -f lib/oozie-client-4.1.0.jar || \
 			curl http://central.maven.org/maven2/org/apache/oozie/oozie-client/4.1.0/oozie-client-4.1.0.jar -o lib/oozie-client-4.1.0.jar

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,10 +26,11 @@ To release a new version of [`pyoozie`](https://pypi.python.org/pypi/pyoozie):
 4. Create a PR to increment [`__version__`](https://github.com/Shopify/pyoozie/blob/6956a38f9677eec8b6ccbfaa5280dbee0503eb20/pyoozie/__init__.py#L41) according to our [versioning standards](https://github.com/Shopify/shopify_python#versioning) that lists the features associated with this release (e.g. [this release PR](https://github.com/Shopify/pyoozie/pull/55))
     - Note that this PR does not necessarily need to be merged to `master` but should be code reviewed
     - Also note that a release does not have to be crafted from current `master` but could branch off and cherry pick specific features to release
-5. Optionally run `python setup.py register -r https://test.pypi.org/legacy/` if the project has been deleted on Test PyPI
-6. Run `make release` to build the release files locally
-7. Run `make upload_test` to upload the release to Test PyPI
-8. Test that the release works by running `pip install -i https://testpypi.python.org/pypi pyoozie` in a fresh virtualenv and make sure that:
+5. Run `make install` to set up dev tools
+6. Optionally run `python setup.py register -r https://test.pypi.org/legacy/` if the project has been deleted on Test PyPI
+7. Run `make release` to build the release files locally
+8. Run `make upload_test` to upload the release to Test PyPI
+9. Test that the release works by running `pip install -i https://testpypi.python.org/pypi pyoozie` in a fresh virtualenv and make sure that:
     - It installs correctly (you may need to manually install its dependencies b/c they probably aren't on Test PyPI); and
     - You can at least import a class/function from the library
-9. If everything looks OK, release to PyPI by running `make upload_pypi`
+10. If everything looks OK, release to PyPI by running `make upload_pypi`

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -23,10 +23,10 @@ To release a new version of [`pyoozie`](https://pypi.python.org/pypi/pyoozie):
     password = <your password goes here>
     ```
 
-4. Create a PR to increment [`__version__`](https://github.com/Shopify/pyoozie/blob/6956a38f9677eec8b6ccbfaa5280dbee0503eb20/pyoozie/__init__.py#L41) according to our [versioning standards](https://github.com/Shopify/shopify_python#versioning) that lists the features associated with this release (e.g. [this release PR](https://github.com/Shopify/pyoozie/pull/55))
+4. Merge a PR that increments [`__version__`](https://github.com/Shopify/pyoozie/blob/6956a38f9677eec8b6ccbfaa5280dbee0503eb20/pyoozie/__init__.py#L41) according to our [versioning standards](https://github.com/Shopify/shopify_python#versioning) that lists the features associated with this release (e.g. [this release PR](https://github.com/Shopify/pyoozie/pull/55))
     - Note that this PR does not necessarily need to be merged to `master` but should be code reviewed
     - Also note that a release does not have to be crafted from current `master` but could branch off and cherry pick specific features to release
-5. Run `make install` to set up dev tools
+5. Check out the latest version of the master branch (unless you have a good reason to release off of master) and run `make install` to set up dev tools
 6. Optionally run `python setup.py register -r https://test.pypi.org/legacy/` if the project has been deleted on Test PyPI
 7. Run `make release` to build the release files locally
 8. Run `make upload_test` to upload the release to Test PyPI

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setuplib.setup(
     ],
     extras_require={
         'deploy': [
+            'twine>=1.9.1',
             'setuptools>=0.9'
         ],
         'test': [


### PR DESCRIPTION
The release instructions assume that you have twine installed to deploy packages, but that may not be the case. This PR adds twine to the required libraries and changes the instructions to encourage their installation prior to usage.