### PR TITLE
Add job_coordinator_rerun

### DIFF
--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -40,7 +40,7 @@ from pyoozie.tags import validate_xml_name
 from pyoozie.tags import WorkflowApp
 
 
-__version__ = '0.0.2'
+__version__ = '0.0.3'
 
 __all__ = (
     # builder


### PR DESCRIPTION
Added `job_coordinator_rerun` which allows us to run the `coord-rerun` action on a coordinator action. Necessary for replicating the logic found here: https://github.com/Shopify/starscream/blob/master/starscream/scheduling/oozie/oozie_utils.py#L114-L125

I've also moved around and renamed `jobs_update_coordinator` since it didn't seem to follow the same pattern as the other functions.

AFAICT, functions starting with `jobs_*` hit the `/jobs` endpoint whereas functions starting with `job_*` hit the `/job` endpoint. Also the action name is typically the suffix of the function name.