### PR TITLE
Delay the connection check until the first request

### DIFF
--- a/pyoozie/client.py
+++ b/pyoozie/client.py
@@ -68,7 +68,7 @@ class OozieClient(object):
         def elapsed(self):
             return self._elapsed
 
-    def __init__(self, url=None, user=None, timeout=None, verbose=True, test_connection=True, **_):
+    def __init__(self, url=None, user=None, timeout=None, verbose=True, **_):
         self.logger = logging.getLogger('pyoozie.OozieClient')
         oozie_url = (url or 'http://localhost').rstrip('/')
         if not oozie_url.endswith('/oozie'):

--- a/pyoozie/client.py
+++ b/pyoozie/client.py
@@ -78,10 +78,9 @@ class OozieClient(object):
         self._timeout = timeout or 30
         self._verbose = verbose  # Note: change default for verbose!
         self._stats = OozieClient.Stats()
-        if test_connection:
-            self.test_connection()
+        self._valid_server = False
 
-    def test_connection(self):
+    def _test_connection(self):
         response = None
         try:
             response = requests.get('{}/versions'.format(self._url), timeout=self._timeout)
@@ -109,6 +108,10 @@ class OozieClient(object):
         return headers
 
     def _request(self, method, endpoint, content_type, content=None):
+        if not self._valid_server:
+            self._test_connection()
+            self._valid_server = True
+
         response = None
         url = '{}/v2/{}'.format(self._url, endpoint)
 

--- a/pyoozie/client.py
+++ b/pyoozie/client.py
@@ -68,7 +68,7 @@ class OozieClient(object):
         def elapsed(self):
             return self._elapsed
 
-    def __init__(self, url=None, user=None, timeout=None, verbose=True, **_):
+    def __init__(self, url=None, user=None, timeout=None, verbose=True, test_connection=True, **_):
         self.logger = logging.getLogger('pyoozie.OozieClient')
         oozie_url = (url or 'http://localhost').rstrip('/')
         if not oozie_url.endswith('/oozie'):
@@ -78,9 +78,10 @@ class OozieClient(object):
         self._timeout = timeout or 30
         self._verbose = verbose  # Note: change default for verbose!
         self._stats = OozieClient.Stats()
-        self._test_connection()
+        if test_connection:
+            self.test_connection()
 
-    def _test_connection(self):
+    def test_connection(self):
         response = None
         try:
             response = requests.get('{}/versions'.format(self._url), timeout=self._timeout)

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setuplib.setup(
             'pylint>=1.7.1,<1.8',
             'pytest-cov',
             'pytest-randomly',
-            'pytest>=2.7',
+            'pytest>=3.0',
             'requests-mock',
             'shopify_python==0.4.1',
             'xmltodict',

--- a/tests/pyoozie/test_client.py
+++ b/tests/pyoozie/test_client.py
@@ -35,8 +35,7 @@ def oozie_config():
 @pytest.fixture
 def api(oozie_config):
     with mock.patch('pyoozie.client.OozieClient._test_connection'):
-        api = client.OozieClient(**oozie_config)
-    return api
+        yield client.OozieClient(**oozie_config)
 
 
 @pytest.fixture
@@ -151,31 +150,30 @@ class TestOozieClientCore(object):
     @mock.patch('pyoozie.client.OozieClient._test_connection')
     def test_construction(self, mock_test_conn, oozie_config):
         api = client.OozieClient(**oozie_config)
-        assert mock_test_conn.called
+        assert not mock_test_conn.called
         assert api._url == 'http://localhost:11000/oozie'
 
     def test_test_connection(self, oozie_config):
         with requests_mock.mock() as m:
+            m.get('http://localhost:11000/oozie/v2/admin/build-version', text='{}')
+
             m.get('http://localhost:11000/oozie/versions', text='[0, 1, 2]')
-            client.OozieClient(**oozie_config)
+            client.OozieClient(**oozie_config).admin_build_version()
 
-        with pytest.raises(exceptions.OozieException) as err:
-            with requests_mock.mock() as m:
-                m.get('http://localhost:11000/oozie/versions', text='[0, 1]')
-                client.OozieClient(**oozie_config)
-        assert 'does not support API version 2' in str(err)
+            m.get('http://localhost:11000/oozie/versions', text='[0, 1]')
+            with pytest.raises(exceptions.OozieException) as err:
+                client.OozieClient(**oozie_config).admin_build_version()
+            assert 'does not support API version 2' in str(err)
 
-        with pytest.raises(exceptions.OozieException) as err:
-            with requests_mock.mock() as m:
-                m.get('http://localhost:11000/oozie/versions', status_code=404)
-                client.OozieClient(**oozie_config)
-        assert 'Unable to contact Oozie server' in str(err)
+            m.get('http://localhost:11000/oozie/versions', status_code=404)
+            with pytest.raises(exceptions.OozieException) as err:
+                client.OozieClient(**oozie_config).admin_build_version()
+            assert 'Unable to contact Oozie server' in str(err)
 
-        with pytest.raises(exceptions.OozieException) as err:
-            with requests_mock.mock() as m:
-                m.get('http://localhost:11000/oozie/versions', text='>>> fail <<<')
-                client.OozieClient(**oozie_config)
-        assert 'Invalid response from Oozie server' in str(err)
+            m.get('http://localhost:11000/oozie/versions', text='>>> fail <<<')
+            with pytest.raises(exceptions.OozieException) as err:
+                client.OozieClient(**oozie_config).admin_build_version()
+            assert 'Invalid response from Oozie server' in str(err)
 
     def test_request(self, api):
         with requests_mock.mock() as m:

--- a/tests/pyoozie/test_client.py
+++ b/tests/pyoozie/test_client.py
@@ -34,7 +34,7 @@ def oozie_config():
 
 @pytest.fixture
 def api(oozie_config):
-    with mock.patch('pyoozie.client.OozieClient.test_connection'):
+    with mock.patch('pyoozie.client.OozieClient._test_connection'):
         api = client.OozieClient(**oozie_config)
     return api
 
@@ -148,7 +148,7 @@ def sample_workflow_prep(api):
 
 class TestOozieClientCore(object):
 
-    @mock.patch('pyoozie.client.OozieClient.test_connection')
+    @mock.patch('pyoozie.client.OozieClient._test_connection')
     def test_construction(self, mock_test_conn, oozie_config):
         api = client.OozieClient(**oozie_config)
         assert mock_test_conn.called

--- a/tests/pyoozie/test_client.py
+++ b/tests/pyoozie/test_client.py
@@ -34,7 +34,7 @@ def oozie_config():
 
 @pytest.fixture
 def api(oozie_config):
-    with mock.patch('pyoozie.client.OozieClient._test_connection'):
+    with mock.patch('pyoozie.client.OozieClient.test_connection'):
         api = client.OozieClient(**oozie_config)
     return api
 
@@ -148,7 +148,7 @@ def sample_workflow_prep(api):
 
 class TestOozieClientCore(object):
 
-    @mock.patch('pyoozie.client.OozieClient._test_connection')
+    @mock.patch('pyoozie.client.OozieClient.test_connection')
     def test_construction(self, mock_test_conn, oozie_config):
         api = client.OozieClient(**oozie_config)
         assert mock_test_conn.called


### PR DESCRIPTION
# Why

The `OozieClient` constructor is performing a connection check. 
This can make testing harder than it should be.

# How

- Add an argument to disable the check in the constructor
- Make the `test_connection` method part of the API

Resolves #63