### PR TITLE
Universal wheel (py2/3)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[bdist_wheel]
+universal=1
+
 [pycodestyle]
 max-line-length = 120
 


### PR DESCRIPTION
## Why

Publishing wheels for py2 and py3 currently require switching to a different virtualenv to generate the wheels.

## How 

Enable the [universal-wheel](https://packaging.python.org/tutorials/distributing-packages/#universal-wheels) option.