### PR TITLE
Allow specifying details flag to avoid extra REST calls

### DIFF
--- a/pyoozie/client.py
+++ b/pyoozie/client.py
@@ -256,15 +256,15 @@ class OozieClient(object):
     def jobs_all_workflows(self, name=None, user=None, limit=0):
         return self._jobs_query(model.ArtifactType.Workflow, name=name, user=user, limit=limit)
 
-    def jobs_all_active_workflows(self, user=None):
-        return self._jobs_query(model.ArtifactType.Workflow, status=model.WorkflowStatus.active(), user=user)
+    def jobs_all_active_workflows(self, user=None, details=True):
+        return self._jobs_query(model.ArtifactType.Workflow, status=model.WorkflowStatus.active(), user=user, details=details)
 
-    def jobs_all_running_workflows(self, user=None):
-        return self._jobs_query(model.ArtifactType.Workflow, status=model.WorkflowStatus.running(), user=user)
+    def jobs_all_running_workflows(self, user=None, details=True):
+        return self._jobs_query(model.ArtifactType.Workflow, status=model.WorkflowStatus.running(), user=user, details=details)
 
-    def jobs_running_workflows(self, name, user=None):
+    def jobs_running_workflows(self, name, user=None, details=True):
         return self._jobs_query(
-            model.ArtifactType.Workflow, name=name, status=model.WorkflowStatus.running(), user=user)
+            model.ArtifactType.Workflow, name=name, status=model.WorkflowStatus.running(), user=user, details=details)
 
     def jobs_last_workflow(self, name, user=None):
         jobs = self._jobs_query(model.ArtifactType.Workflow, name=name, user=user, limit=1)
@@ -273,18 +273,18 @@ class OozieClient(object):
         else:
             raise exceptions.OozieException.workflow_not_found(name)
 
-    def jobs_workflow_names(self, user=None):
-        jobs = self._jobs_query(model.ArtifactType.Workflow, user=user, details=False)
+    def jobs_workflow_names(self, user=None, limit=0):
+        jobs = self._jobs_query(model.ArtifactType.Workflow, user=user, details=False, limit=limit)
         return set([job.appName for job in jobs])
 
-    def jobs_all_coordinators(self, name=None, user=None, limit=0):
-        return self._jobs_query(model.ArtifactType.Coordinator, name=name, user=user, limit=limit)
+    def jobs_all_coordinators(self, name=None, user=None, limit=0, details=True):
+        return self._jobs_query(model.ArtifactType.Coordinator, name=name, user=user, limit=limit, details=details)
 
-    def jobs_all_active_coordinators(self, user=None):
-        return self._jobs_query(model.ArtifactType.Coordinator, status=model.CoordinatorStatus.active(), user=user)
+    def jobs_all_active_coordinators(self, user=None, details=True):
+        return self._jobs_query(model.ArtifactType.Coordinator, status=model.CoordinatorStatus.active(), user=user, details=details)
 
-    def jobs_all_running_coordinators(self, user=None):
-        return self._jobs_query(model.ArtifactType.Coordinator, status=model.CoordinatorStatus.running(), user=user)
+    def jobs_all_running_coordinators(self, user=None, details=True):
+        return self._jobs_query(model.ArtifactType.Coordinator, status=model.CoordinatorStatus.running(), user=user, details=details)
 
     def jobs_all_suspended_coordinators(self, user=None):
         return self._jobs_query(model.ArtifactType.Coordinator, status=model.CoordinatorStatus.suspended(), user=user)

--- a/pyoozie/client.py
+++ b/pyoozie/client.py
@@ -257,10 +257,12 @@ class OozieClient(object):
         return self._jobs_query(model.ArtifactType.Workflow, name=name, user=user, limit=limit)
 
     def jobs_all_active_workflows(self, user=None, details=True):
-        return self._jobs_query(model.ArtifactType.Workflow, status=model.WorkflowStatus.active(), user=user, details=details)
+        return self._jobs_query(
+            model.ArtifactType.Workflow, status=model.WorkflowStatus.active(), user=user, details=details)
 
     def jobs_all_running_workflows(self, user=None, details=True):
-        return self._jobs_query(model.ArtifactType.Workflow, status=model.WorkflowStatus.running(), user=user, details=details)
+        return self._jobs_query(
+            model.ArtifactType.Workflow, status=model.WorkflowStatus.running(), user=user, details=details)
 
     def jobs_running_workflows(self, name, user=None, details=True):
         return self._jobs_query(
@@ -281,10 +283,12 @@ class OozieClient(object):
         return self._jobs_query(model.ArtifactType.Coordinator, name=name, user=user, limit=limit, details=details)
 
     def jobs_all_active_coordinators(self, user=None, details=True):
-        return self._jobs_query(model.ArtifactType.Coordinator, status=model.CoordinatorStatus.active(), user=user, details=details)
+        return self._jobs_query(
+            model.ArtifactType.Coordinator, status=model.CoordinatorStatus.active(), user=user, details=details)
 
     def jobs_all_running_coordinators(self, user=None, details=True):
-        return self._jobs_query(model.ArtifactType.Coordinator, status=model.CoordinatorStatus.running(), user=user, details=details)
+        return self._jobs_query(
+            model.ArtifactType.Coordinator, status=model.CoordinatorStatus.running(), user=user, details=details)
 
     def jobs_all_suspended_coordinators(self, user=None):
         return self._jobs_query(model.ArtifactType.Coordinator, status=model.CoordinatorStatus.suspended(), user=user)

--- a/pyoozie/client.py
+++ b/pyoozie/client.py
@@ -239,7 +239,7 @@ class OozieClient(object):
         job_type, result_type = self.JOB_TYPE_STRINGS[type_enum]
         filters = self._filter_string(type_enum, user=user, name=name, status=status)
         offset = 1
-        chunk = limit if limit else 500
+        chunk = min(limit or 5000, 5000)
         jobs = []
         while True:
             result = self._get('jobs?jobtype={}{}&offset={}&len={}'.format(job_type, filters, offset, chunk))

--- a/tests/pyoozie/test_client.py
+++ b/tests/pyoozie/test_client.py
@@ -463,10 +463,10 @@ class TestOozieClientJobsQuery(object):
             mock_query.return_value = [sample_workflow_running]
 
             api.jobs_all_active_workflows()
-            mock_query.assert_called_with(model.ArtifactType.Workflow, user=None, status=expected_statuses)
+            mock_query.assert_called_with(model.ArtifactType.Workflow, details=True, user=None, status=expected_statuses)
 
             api.jobs_all_active_workflows(user='john_doe')
-            mock_query.assert_called_with(model.ArtifactType.Workflow, user='john_doe', status=expected_statuses)
+            mock_query.assert_called_with(model.ArtifactType.Workflow, details=True, user='john_doe', status=expected_statuses)
 
     def test_jobs_all_running_workflows(self, api, sample_workflow_running):
         expected_statuses = model.WorkflowStatus.running()
@@ -474,10 +474,10 @@ class TestOozieClientJobsQuery(object):
             mock_query.return_value = [sample_workflow_running]
 
             api.jobs_all_running_workflows()
-            mock_query.assert_called_with(model.ArtifactType.Workflow, user=None, status=expected_statuses)
+            mock_query.assert_called_with(model.ArtifactType.Workflow, details=True, user=None, status=expected_statuses)
 
             api.jobs_all_running_workflows(user='john_doe')
-            mock_query.assert_called_with(model.ArtifactType.Workflow, user='john_doe', status=expected_statuses)
+            mock_query.assert_called_with(model.ArtifactType.Workflow, details=True, user='john_doe', status=expected_statuses)
 
     def test_jobs_running_workflows(self, api, sample_workflow_running):
         expected_statuses = model.WorkflowStatus.running()
@@ -487,6 +487,7 @@ class TestOozieClientJobsQuery(object):
             api.jobs_running_workflows('my_workflow')
             mock_query.assert_called_with(
                 model.ArtifactType.Workflow,
+                details=True,
                 name='my_workflow',
                 user=None,
                 status=expected_statuses)
@@ -494,6 +495,7 @@ class TestOozieClientJobsQuery(object):
             api.jobs_running_workflows('my_workflow', user='john_doe')
             mock_query.assert_called_with(
                 model.ArtifactType.Workflow,
+                details=True,
                 name='my_workflow',
                 user='john_doe',
                 status=expected_statuses)
@@ -513,27 +515,28 @@ class TestOozieClientJobsQuery(object):
             mock_query.return_value = []
 
             api.jobs_workflow_names()
-            mock_query.assert_called_with(model.ArtifactType.Workflow, user=None, details=False)
+            mock_query.assert_called_with(model.ArtifactType.Workflow, user=None, details=False, limit=0)
 
             api.jobs_workflow_names(user='john_doe')
-            mock_query.assert_called_with(model.ArtifactType.Workflow, user='john_doe', details=False)
+            mock_query.assert_called_with(model.ArtifactType.Workflow, user='john_doe', details=False, limit=0)
 
     def test_jobs_all_coordinators(self, api, sample_coordinator_running):
         with mock.patch.object(api, '_jobs_query') as mock_query:
             mock_query.return_value = [sample_coordinator_running]
 
             api.jobs_all_coordinators()
-            mock_query.assert_called_with(model.ArtifactType.Coordinator, name=None, user=None, limit=0)
+            mock_query.assert_called_with(model.ArtifactType.Coordinator, details=True, name=None, user=None, limit=0)
 
             api.jobs_all_coordinators(name='my_coordinator')
-            mock_query.assert_called_with(model.ArtifactType.Coordinator, name='my_coordinator', user=None, limit=0)
+            mock_query.assert_called_with(model.ArtifactType.Coordinator, details=True, name='my_coordinator', user=None, limit=0)
 
             api.jobs_all_coordinators(user='john_doe')
-            mock_query.assert_called_with(model.ArtifactType.Coordinator, name=None, user='john_doe', limit=0)
+            mock_query.assert_called_with(model.ArtifactType.Coordinator, details=True, name=None, user='john_doe', limit=0)
 
             api.jobs_all_coordinators(name='my_coordinator', user='john_doe')
             mock_query.assert_called_with(
                 model.ArtifactType.Coordinator,
+                details=True,
                 name='my_coordinator',
                 user='john_doe',
                 limit=0)
@@ -541,6 +544,7 @@ class TestOozieClientJobsQuery(object):
             api.jobs_all_coordinators(name='my_coordinator', limit=1)
             mock_query.assert_called_with(
                 model.ArtifactType.Coordinator,
+                details=True,
                 name='my_coordinator',
                 user=None,
                 limit=1)
@@ -551,10 +555,10 @@ class TestOozieClientJobsQuery(object):
             mock_query.return_value = [sample_coordinator_running]
 
             api.jobs_all_active_coordinators()
-            mock_query.assert_called_with(model.ArtifactType.Coordinator, user=None, status=expected_statuses)
+            mock_query.assert_called_with(model.ArtifactType.Coordinator, details=True, user=None, status=expected_statuses)
 
             api.jobs_all_active_coordinators(user='john_doe')
-            mock_query.assert_called_with(model.ArtifactType.Coordinator, user='john_doe', status=expected_statuses)
+            mock_query.assert_called_with(model.ArtifactType.Coordinator, details=True, user='john_doe', status=expected_statuses)
 
     def test_jobs_all_running_coordinators(self, api, sample_coordinator_running):
         expected_statuses = model.CoordinatorStatus.running()
@@ -562,10 +566,10 @@ class TestOozieClientJobsQuery(object):
             mock_query.return_value = [sample_coordinator_running]
 
             api.jobs_all_running_coordinators()
-            mock_query.assert_called_with(model.ArtifactType.Coordinator, user=None, status=expected_statuses)
+            mock_query.assert_called_with(model.ArtifactType.Coordinator, details=True, user=None, status=expected_statuses)
 
             api.jobs_all_running_coordinators(user='john_doe')
-            mock_query.assert_called_with(model.ArtifactType.Coordinator, user='john_doe', status=expected_statuses)
+            mock_query.assert_called_with(model.ArtifactType.Coordinator, details=True, user='john_doe', status=expected_statuses)
 
     def test_jobs_all_suspended_coordinators(self, api, sample_coordinator_suspended):
         expected_statuses = model.CoordinatorStatus.suspended()

--- a/tests/pyoozie/test_client.py
+++ b/tests/pyoozie/test_client.py
@@ -434,7 +434,6 @@ class TestOozieClientJobsQuery(object):
             with pytest.raises(StopIteration):
                 next(mock_results)
 
-
     @mock.patch.object(model.Workflow, 'fill_in_details', side_effect=lambda c: c, autospec=True)
     def test_jobs_query_workflow_details(self, fill_in_details, api):
         mock_result = {
@@ -494,10 +493,14 @@ class TestOozieClientJobsQuery(object):
             mock_query.return_value = [sample_workflow_running]
 
             api.jobs_all_active_workflows()
-            mock_query.assert_called_with(model.ArtifactType.Workflow, details=True, user=None, status=expected_statuses)
+            mock_query.assert_called_with(
+                model.ArtifactType.Workflow, details=True, user=None, status=expected_statuses
+            )
 
             api.jobs_all_active_workflows(user='john_doe')
-            mock_query.assert_called_with(model.ArtifactType.Workflow, details=True, user='john_doe', status=expected_statuses)
+            mock_query.assert_called_with(
+                model.ArtifactType.Workflow, details=True, user='john_doe', status=expected_statuses
+            )
 
     def test_jobs_all_running_workflows(self, api, sample_workflow_running):
         expected_statuses = model.WorkflowStatus.running()
@@ -505,10 +508,14 @@ class TestOozieClientJobsQuery(object):
             mock_query.return_value = [sample_workflow_running]
 
             api.jobs_all_running_workflows()
-            mock_query.assert_called_with(model.ArtifactType.Workflow, details=True, user=None, status=expected_statuses)
+            mock_query.assert_called_with(
+                model.ArtifactType.Workflow, details=True, user=None, status=expected_statuses
+            )
 
             api.jobs_all_running_workflows(user='john_doe')
-            mock_query.assert_called_with(model.ArtifactType.Workflow, details=True, user='john_doe', status=expected_statuses)
+            mock_query.assert_called_with(
+                model.ArtifactType.Workflow, details=True, user='john_doe', status=expected_statuses
+            )
 
     def test_jobs_running_workflows(self, api, sample_workflow_running):
         expected_statuses = model.WorkflowStatus.running()
@@ -556,13 +563,19 @@ class TestOozieClientJobsQuery(object):
             mock_query.return_value = [sample_coordinator_running]
 
             api.jobs_all_coordinators()
-            mock_query.assert_called_with(model.ArtifactType.Coordinator, details=True, name=None, user=None, limit=0)
+            mock_query.assert_called_with(
+                model.ArtifactType.Coordinator, details=True, name=None, user=None, limit=0
+            )
 
             api.jobs_all_coordinators(name='my_coordinator')
-            mock_query.assert_called_with(model.ArtifactType.Coordinator, details=True, name='my_coordinator', user=None, limit=0)
+            mock_query.assert_called_with(
+                model.ArtifactType.Coordinator, details=True, name='my_coordinator', user=None, limit=0
+            )
 
             api.jobs_all_coordinators(user='john_doe')
-            mock_query.assert_called_with(model.ArtifactType.Coordinator, details=True, name=None, user='john_doe', limit=0)
+            mock_query.assert_called_with(
+                model.ArtifactType.Coordinator, details=True, name=None, user='john_doe', limit=0
+            )
 
             api.jobs_all_coordinators(name='my_coordinator', user='john_doe')
             mock_query.assert_called_with(
@@ -586,10 +599,14 @@ class TestOozieClientJobsQuery(object):
             mock_query.return_value = [sample_coordinator_running]
 
             api.jobs_all_active_coordinators()
-            mock_query.assert_called_with(model.ArtifactType.Coordinator, details=True, user=None, status=expected_statuses)
+            mock_query.assert_called_with(
+                model.ArtifactType.Coordinator, details=True, user=None, status=expected_statuses
+            )
 
             api.jobs_all_active_coordinators(user='john_doe')
-            mock_query.assert_called_with(model.ArtifactType.Coordinator, details=True, user='john_doe', status=expected_statuses)
+            mock_query.assert_called_with(
+                model.ArtifactType.Coordinator, details=True, user='john_doe', status=expected_statuses
+            )
 
     def test_jobs_all_running_coordinators(self, api, sample_coordinator_running):
         expected_statuses = model.CoordinatorStatus.running()
@@ -597,10 +614,14 @@ class TestOozieClientJobsQuery(object):
             mock_query.return_value = [sample_coordinator_running]
 
             api.jobs_all_running_coordinators()
-            mock_query.assert_called_with(model.ArtifactType.Coordinator, details=True, user=None, status=expected_statuses)
+            mock_query.assert_called_with(
+                model.ArtifactType.Coordinator, details=True, user=None, status=expected_statuses
+            )
 
             api.jobs_all_running_coordinators(user='john_doe')
-            mock_query.assert_called_with(model.ArtifactType.Coordinator, details=True, user='john_doe', status=expected_statuses)
+            mock_query.assert_called_with(
+                model.ArtifactType.Coordinator, details=True, user='john_doe', status=expected_statuses
+            )
 
     def test_jobs_all_suspended_coordinators(self, api, sample_coordinator_suspended):
         expected_statuses = model.CoordinatorStatus.suspended()

--- a/tests/pyoozie/test_client.py
+++ b/tests/pyoozie/test_client.py
@@ -293,19 +293,19 @@ class TestOozieClientJobsQuery(object):
             mock_get.return_value = mock_result
 
             api._jobs_query(model.ArtifactType.Workflow)
-            mock_get.assert_called_with('jobs?jobtype=wf&offset=1&len=500')
+            mock_get.assert_called_with('jobs?jobtype=wf&offset=1&len=5000')
 
             api._jobs_query(model.ArtifactType.Workflow, user='john_doe')
-            mock_get.assert_called_with('jobs?jobtype=wf&filter=user=john_doe&offset=1&len=500')
+            mock_get.assert_called_with('jobs?jobtype=wf&filter=user=john_doe&offset=1&len=5000')
 
             api._jobs_query(model.ArtifactType.Workflow, name='my_workflow')
-            mock_get.assert_called_with('jobs?jobtype=wf&filter=name=my_workflow&offset=1&len=500')
+            mock_get.assert_called_with('jobs?jobtype=wf&filter=name=my_workflow&offset=1&len=5000')
 
             api._jobs_query(model.ArtifactType.Workflow, status=model.WorkflowStatus.RUNNING)
-            mock_get.assert_called_with('jobs?jobtype=wf&filter=status=RUNNING&offset=1&len=500')
+            mock_get.assert_called_with('jobs?jobtype=wf&filter=status=RUNNING&offset=1&len=5000')
 
             api._jobs_query(model.ArtifactType.Workflow, status=model.WorkflowStatus.running())
-            mock_get.assert_called_with('jobs?jobtype=wf&filter=status=RUNNING;status=SUSPENDED&offset=1&len=500')
+            mock_get.assert_called_with('jobs?jobtype=wf&filter=status=RUNNING;status=SUSPENDED&offset=1&len=5000')
 
             api._jobs_query(
                 model.ArtifactType.Workflow,
@@ -313,7 +313,7 @@ class TestOozieClientJobsQuery(object):
                 name='my_workflow',
                 status=model.WorkflowStatus.running())
             mock_get.assert_called_with('jobs?jobtype=wf&filter=user=john_doe;name=my_workflow;status=RUNNING;'
-                                        'status=SUSPENDED&offset=1&len=500')
+                                        'status=SUSPENDED&offset=1&len=5000')
 
     def test_jobs_query_coordinator_parameters(self, api):
         mock_result = {
@@ -324,20 +324,20 @@ class TestOozieClientJobsQuery(object):
             mock_get.return_value = mock_result
 
             api._jobs_query(model.ArtifactType.Coordinator)
-            mock_get.assert_called_with('jobs?jobtype=coordinator&offset=1&len=500')
+            mock_get.assert_called_with('jobs?jobtype=coordinator&offset=1&len=5000')
 
             api._jobs_query(model.ArtifactType.Coordinator, user='john_doe')
-            mock_get.assert_called_with('jobs?jobtype=coordinator&filter=user=john_doe&offset=1&len=500')
+            mock_get.assert_called_with('jobs?jobtype=coordinator&filter=user=john_doe&offset=1&len=5000')
 
             api._jobs_query(model.ArtifactType.Coordinator, name='my_coordinator')
-            mock_get.assert_called_with('jobs?jobtype=coordinator&filter=name=my_coordinator&offset=1&len=500')
+            mock_get.assert_called_with('jobs?jobtype=coordinator&filter=name=my_coordinator&offset=1&len=5000')
 
             api._jobs_query(model.ArtifactType.Coordinator, status=model.CoordinatorStatus.RUNNING)
-            mock_get.assert_called_with('jobs?jobtype=coordinator&filter=status=RUNNING&offset=1&len=500')
+            mock_get.assert_called_with('jobs?jobtype=coordinator&filter=status=RUNNING&offset=1&len=5000')
 
             api._jobs_query(model.ArtifactType.Coordinator, status=model.CoordinatorStatus.running())
             mock_get.assert_called_with('jobs?jobtype=coordinator&filter=status=RUNNING;status=RUNNINGWITHERROR;'
-                                        'status=SUSPENDED;status=SUSPENDEDWITHERROR&offset=1&len=500')
+                                        'status=SUSPENDED;status=SUSPENDEDWITHERROR&offset=1&len=5000')
 
             api._jobs_query(
                 model.ArtifactType.Coordinator,
@@ -346,7 +346,7 @@ class TestOozieClientJobsQuery(object):
                 status=model.CoordinatorStatus.running())
             mock_get.assert_called_with('jobs?jobtype=coordinator&filter=user=john_doe;name=my_coordinator;'
                                         'status=RUNNING;status=RUNNINGWITHERROR;status=SUSPENDED;'
-                                        'status=SUSPENDEDWITHERROR&offset=1&len=500')
+                                        'status=SUSPENDEDWITHERROR&offset=1&len=5000')
 
     def test_jobs_query_bad_parameters(self, api):
         with pytest.raises(KeyError) as err:
@@ -362,11 +362,11 @@ class TestOozieClientJobsQuery(object):
         mock_results = iter(
             [
                 {
-                    'total': 501,
+                    'total': 5001,
                     'workflows': [{'id': '1-W'}, {'id': '2-W'}]
                 },
                 {
-                    'total': 501,
+                    'total': 5001,
                     'workflows': [{'id': '3-W'}]
                 }
             ]
@@ -375,8 +375,8 @@ class TestOozieClientJobsQuery(object):
             mock_get.side_effect = lambda url: next(mock_results)
             result = api._jobs_query(model.ArtifactType.Workflow)
             assert len(result) == 3
-            mock_get.assert_any_call('jobs?jobtype=wf&offset=1&len=500')
-            mock_get.assert_any_call('jobs?jobtype=wf&offset=501&len=500')
+            mock_get.assert_any_call('jobs?jobtype=wf&offset=1&len=5000')
+            mock_get.assert_any_call('jobs?jobtype=wf&offset=5001&len=5000')
             with pytest.raises(StopIteration):
                 next(mock_results)
 
@@ -385,11 +385,11 @@ class TestOozieClientJobsQuery(object):
         mock_results = iter(
             [
                 {
-                    'total': 501,
+                    'total': 5001,
                     'coordinatorjobs': [{'coordJobId': '1-C'}, {'coordJobId': '2-C'}]
                 },
                 {
-                    'total': 501,
+                    'total': 5001,
                     'coordinatorjobs': [{'coordJobId': '3-C'}]
                 }
             ]
@@ -399,10 +399,41 @@ class TestOozieClientJobsQuery(object):
             mock_get.side_effect = lambda url: next(mock_results)
             result = api._jobs_query(model.ArtifactType.Coordinator)
             assert len(result) == 3
-            mock_get.assert_any_call('jobs?jobtype=coordinator&offset=1&len=500')
-            mock_get.assert_any_call('jobs?jobtype=coordinator&offset=501&len=500')
+            mock_get.assert_any_call('jobs?jobtype=coordinator&offset=1&len=5000')
+            mock_get.assert_any_call('jobs?jobtype=coordinator&offset=5001&len=5000')
             with pytest.raises(StopIteration):
                 next(mock_results)
+
+    @mock.patch.object(model.Coordinator, 'fill_in_details', side_effect=lambda c: c, autospec=True)
+    def test_jobs_query_coordinator_limit(self, _, api):
+        # mock_result = {'total': 1, 'coordinatorjobs': [{'coordJobId': '3-C'}]}
+        mock_results = iter(
+            [
+                {
+                    'total': 2,
+                    'coordinatorjobs': [{'coordJobId': '1-C'}, {'coordJobId': '2-C'}]
+                },
+                {
+                    'total': 5001,
+                    'coordinatorjobs': [{'coordJobId': '1-C'}, {'coordJobId': '2-C'}]
+                },
+                {
+                    'total': 5001,
+                    'coordinatorjobs': [{'coordJobId': '3-C'}]
+                }
+            ]
+        )
+
+        with mock.patch.object(api, '_get') as mock_get:
+            mock_get.side_effect = lambda url: next(mock_results)
+            api._jobs_query(model.ArtifactType.Coordinator, limit=5)
+            mock_get.assert_called_with('jobs?jobtype=coordinator&offset=1&len=5')
+            api._jobs_query(model.ArtifactType.Coordinator, limit=6000)
+            mock_get.assert_any_call('jobs?jobtype=coordinator&offset=1&len=5000')
+            mock_get.assert_any_call('jobs?jobtype=coordinator&offset=5001&len=5000')
+            with pytest.raises(StopIteration):
+                next(mock_results)
+
 
     @mock.patch.object(model.Workflow, 'fill_in_details', side_effect=lambda c: c, autospec=True)
     def test_jobs_query_workflow_details(self, fill_in_details, api):
@@ -414,11 +445,11 @@ class TestOozieClientJobsQuery(object):
             mock_get.return_value = mock_result
 
             api._jobs_query(model.ArtifactType.Workflow, details=False)
-            mock_get.assert_called_with('jobs?jobtype=wf&offset=1&len=500')
+            mock_get.assert_called_with('jobs?jobtype=wf&offset=1&len=5000')
             assert not fill_in_details.called
 
             api._jobs_query(model.ArtifactType.Workflow, details=True)
-            mock_get.assert_called_with('jobs?jobtype=wf&offset=1&len=500')
+            mock_get.assert_called_with('jobs?jobtype=wf&offset=1&len=5000')
             assert fill_in_details.called
 
     @mock.patch.object(model.Coordinator, 'fill_in_details', side_effect=lambda c: c, autospec=True)
@@ -431,11 +462,11 @@ class TestOozieClientJobsQuery(object):
             mock_get.return_value = mock_result
 
             api._jobs_query(model.ArtifactType.Coordinator, details=False)
-            mock_get.assert_called_with('jobs?jobtype=coordinator&offset=1&len=500')
+            mock_get.assert_called_with('jobs?jobtype=coordinator&offset=1&len=5000')
             assert not fill_in_details.called
 
             api._jobs_query(model.ArtifactType.Coordinator, details=True)
-            mock_get.assert_called_with('jobs?jobtype=coordinator&offset=1&len=500')
+            mock_get.assert_called_with('jobs?jobtype=coordinator&offset=1&len=5000')
             assert fill_in_details.called
 
     def test_jobs_all_workflows(self, api, sample_workflow_running):


### PR DESCRIPTION
Surface the `details` flag to avoid making additional REST calls (1 per item in the list) when the extra details are not necessary.