### PR TITLE
Surface the client URL used to obtain a model

### DIFF
--- a/pyoozie/client.py
+++ b/pyoozie/client.py
@@ -156,6 +156,10 @@ class OozieClient(object):
     def _post(self, endpoint, content, content_type='application/xml'):
         return self._request('POST', endpoint, content_type, content)
 
+    @property
+    def url(self):
+        return self._url
+
     def report_stats(self, to_logger=None):
         if not to_logger:
             to_logger = self.logger

--- a/pyoozie/model.py
+++ b/pyoozie/model.py
@@ -287,6 +287,10 @@ class _OozieArtifact(object):
         # If values are missing, extrapolate them
         pass
 
+    @property
+    def client_url(self):
+        return self._client.url if self._client else None
+
     def is_coordinator(self):
         return False
 


### PR DESCRIPTION
Adds a `client_url` property to each model.

This makes it easier to use pyoozie models in an environment that has multiple oozie deployements.