### PR TITLE
Replace requests convenience methods with session object 

### DIFF
--- a/pyoozie/client.py
+++ b/pyoozie/client.py
@@ -68,7 +68,7 @@ class OozieClient(object):
         def elapsed(self):
             return self._elapsed
 
-    def __init__(self, url=None, user=None, timeout=None, verbose=True, **_):
+    def __init__(self, url=None, user=None, timeout=None, verbose=True, session=None, **_):
         self.logger = logging.getLogger('pyoozie.OozieClient')
         oozie_url = (url or 'http://localhost').rstrip('/')
         if not oozie_url.endswith('/oozie'):
@@ -79,11 +79,12 @@ class OozieClient(object):
         self._verbose = verbose  # Note: change default for verbose!
         self._stats = OozieClient.Stats()
         self._valid_server = False
+        self._session = session or requests.Session()
 
     def _test_connection(self):
         response = None
         try:
-            response = requests.get('{}/versions'.format(self._url), timeout=self._timeout)
+            response = self._session.get('{}/versions'.format(self._url), timeout=self._timeout)
             response.raise_for_status()
             self._stats.update(response)
         except requests.RequestException as err:
@@ -122,8 +123,8 @@ class OozieClient(object):
                 self.logger.info("Request: %s %s", method, url)
 
         try:
-            response = requests.request(method, url, data=content, timeout=self._timeout,
-                                        headers=self._headers(content_type))
+            response = self._session.request(method, url, data=content, timeout=self._timeout,
+                                             headers=self._headers(content_type))
             response.raise_for_status()
         except requests.RequestException as err:
             self._stats.update(response)

--- a/pyoozie/client.py
+++ b/pyoozie/client.py
@@ -79,7 +79,9 @@ class OozieClient(object):
         self._verbose = verbose  # Note: change default for verbose!
         self._stats = OozieClient.Stats()
         self._valid_server = False
-        self._session = session or requests.Session()
+        if not type(session) == requests.sessions.Session: 
+            session = requests.Session()
+        self._session = session
 
     def _test_connection(self):
         response = None

--- a/pyoozie/client.py
+++ b/pyoozie/client.py
@@ -79,9 +79,7 @@ class OozieClient(object):
         self._verbose = verbose  # Note: change default for verbose!
         self._stats = OozieClient.Stats()
         self._valid_server = False
-        if not type(session) == requests.sessions.Session: 
-            session = requests.Session()
-        self._session = session
+        self._session = session or requests.Session()
 
     def _test_connection(self):
         response = None

--- a/tests/pyoozie/test_client.py
+++ b/tests/pyoozie/test_client.py
@@ -38,13 +38,14 @@ def api(oozie_config):
     with mock.patch('pyoozie.client.OozieClient._test_connection'):
         yield client.OozieClient(**oozie_config)
 
+
 @pytest.fixture
 def api_with_session(oozie_config):
     with mock.patch('pyoozie.client.OozieClient._test_connection'):
         session = requests.Session()
         session.headers.update({'test-header': 'true'})
         yield client.OozieClient(session=session, **oozie_config)
-    
+
 
 @pytest.fixture
 def sample_coordinator_running(api):
@@ -160,19 +161,15 @@ class TestOozieClientCore(object):
         api = client.OozieClient(**oozie_config)
         assert not mock_test_conn.called
         assert api._url == 'http://localhost:11000/oozie'
-        assert api._session 
+        assert api._session
 
     @mock.patch('pyoozie.client.OozieClient._test_connection')
     def test_contruction_custom_session(self, mock_test_conn, oozie_config):
         session = requests.Session()
-        session.auth=('user', 'pass')
-
+        session.auth = ('user', 'pass')
         api = client.OozieClient(session=session, **oozie_config)
+        assert not mock_test_conn.called
         assert api._session.auth == session.auth
-
-        session = "not a session object"
-        api = client.OozieClient(session=session, **oozie_config)
-        assert type(api._session) == requests.sessions.Session
 
     def test_test_connection(self, oozie_config):
         with requests_mock.mock() as m:
@@ -212,7 +209,6 @@ class TestOozieClientCore(object):
             m.get('http://localhost:11000/oozie/v2/endpoint', text='{"result": "pass"}')
             result = api._request('GET', 'endpoint', None, None)
             assert result['result'] == 'pass'
-            
 
         with requests_mock.mock() as m:
             m.get('http://localhost:11000/oozie/v2/endpoint')
@@ -228,8 +224,8 @@ class TestOozieClientCore(object):
     def test_request_uses_session_params(self, api_with_session):
         with requests_mock.mock() as m:
             m.get('http://localhost:11000/oozie/v2/endpoint', text='{"result": "pass"}')
-
             result = api_with_session._request('GET', 'endpoint', None, None)
+            assert result['result'] == 'pass'
             assert m.last_request.headers['test-header'] == 'true'
 
     def test_get(self, api):

--- a/tests/pyoozie/test_client.py
+++ b/tests/pyoozie/test_client.py
@@ -164,7 +164,7 @@ class TestOozieClientCore(object):
         assert api._session
 
     @mock.patch('pyoozie.client.OozieClient._test_connection')
-    def test_contruction_custom_session(self, mock_test_conn, oozie_config):
+    def test_construction_custom_session(self, mock_test_conn, oozie_config):
         session = requests.Session()
         session.auth = ('user', 'pass')
         api = client.OozieClient(session=session, **oozie_config)


### PR DESCRIPTION
This PR adds a requests.Session() object to OozieClient and replaces the requests convenience methods with the session. This allows OozieClient to pool connections and make more effective use of server resources. 

This will also allow users to pass in their own customized sessions if required. 