### PR TITLE
Update travis.yml so builds pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ python:
    - "3.5"
    - "3.6"
    - "3.7-dev"
-jdk:
-  - openjdk8
 before_install:
   - pip install -U pip setuptools
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: python
 python:
    - "2.7"
@@ -5,6 +7,8 @@ python:
    - "3.5"
    - "3.6"
    - "3.7-dev"
+jdk:
+  - openjdk8
 before_install:
   - pip install -U pip setuptools
 install:
@@ -15,7 +19,3 @@ script:
   - make lint
 notifications:
   email: false
-addons:
-  apt:
-    packages:
-      openjdk-7-jdk


### PR DESCRIPTION
Between the last build and now, `Trusty` was EOL'd and so all builds in TravisCI are now done on `Xenial` by default. The default Java version installed with `Xenial` does not agree with our testing library (default before was 8, now it's 11), so this pr fixes it by explicitly telling TravisCI to run our build on `Trusty`. Also I removed the openjdk7 install step since it was unnecessary (`Trusty` has 8 preinstalled and used by default which works fine). 

I did investigate making the build work on `Xenial` but ran into frustrating issues with Java versioning. Tl;dr it builds with java 11 by default, and the jdk_switcher tool they provide doesn't come included in the java 11 build, and you can only specify a different java default with the jdk key in the yml, but that's only read if your language is set to java which breaks all the python stuff.... so this seems like the best/easiest solution