### PR TITLE
Gate enum34 requirement to python_version < 3.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,9 @@ install:
 		pip install -e ".[test,deploy,docs]"
 		test -d lib || mkdir lib
 		test -f lib/oozie-client-4.1.0.jar || \
-			curl http://central.maven.org/maven2/org/apache/oozie/oozie-client/4.1.0/oozie-client-4.1.0.jar -o lib/oozie-client-4.1.0.jar
+			curl https://repo1.maven.org/maven2/org/apache/oozie/oozie-client/4.1.0/oozie-client-4.1.0.jar -o lib/oozie-client-4.1.0.jar
 		test -f lib/commons-cli-1.2.jar || \
-			curl http://central.maven.org/maven2/commons-cli/commons-cli/1.2/commons-cli-1.2.jar -o lib/commons-cli-1.2.jar
+			curl https://repo1.maven.org/maven2/commons-cli/commons-cli/1.2/commons-cli-1.2.jar -o lib/commons-cli-1.2.jar
 
 test: clean
 		py.test -vv --durations=10 --cov=pyoozie

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuplib.setup(
     url='https://github.com/Shopify/pyoozie',
     packages=['pyoozie'],
     install_requires=[
-        'enum34>=0.9.23',
+        'enum34>=0.9.23 ; python_version<"3.4"',
         'requests>=2.12.3',
         'six>=1.10.0',
         'typing',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuplib.setup(
         'six>=1.10.0',
         'typing',
         'untangle>=1.1.0',
-        'yattag>=1.7.2',
+        'yattag>=1.7.2,<=1.12.2',
     ],
     extras_require={
         'deploy': [
@@ -44,7 +44,7 @@ setuplib.setup(
             'autopep8',
             'flake8',
             'mock',
-            'pycodestyle == 2.2.0',
+            'pycodestyle>=2.2.0,<2.6.0',
             'pylint>=1.7.1,<1.8',
             'pytest-cov>=2.4.0,<2.6',  # pinned, see https://github.com/z4r/python-coveralls/issues/66
             'pytest-randomly',


### PR DESCRIPTION
From Python 3.4 upwards, enum is built into the Python library. Installing enum34 in Python 3.4 upwards leads to issues where [`pip` gets broken](https://stackoverflow.com/a/45716067).

This PR does the following:
- properly gates the enum34 dependency such that it is only installed in versions of python < 3.4.
- updates the maven urls for `oozie-client` as well as `commons-cli`, as the previous URLs were broken.
- Finally, pins some packages for `mypy` type checking to pass