### PR TITLE
Use Python's typing package if available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuplib.setup(
         'enum34>=0.9.23 ; python_version<"3.4"',
         'requests>=2.12.3',
         'six>=1.10.0',
-        'typing',
+        'typing ; python_version<"3.5"',
         'untangle>=1.1.0',
         'yattag>=1.7.2,<=1.12.2',
     ],


### PR DESCRIPTION
The `typing` module was introduced natively with Python 3.5.  This change skip installing it via PIP if the version of Python >= 3.5.

This was causing problems when installing `pyoozie` from another project running Python 3.7.3:

```
  File "/artifacts/virtualenv/python3/lib/python3.7/site-packages/foo/__init__.py", line 1, in <module>
    import typing
  File "/artifacts/virtualenv/python3/lib/python3.7/site-packages/typing.py", line 1357, in <module>
    class Callable(extra=collections_abc.Callable, metaclass=CallableMeta):
  File "/artifacts/virtualenv/python3/lib/python3.7/site-packages/typing.py", line 1005, in __new__
    self._abc_registry = extra._abc_registry
AttributeError: type object 'Callable' has no attribute '_abc_registry'
```