### PR TITLE
Release version 0.0.9

### DIFF
--- a/pyoozie/__init__.py
+++ b/pyoozie/__init__.py
@@ -39,7 +39,7 @@ from pyoozie.tags import validate_xml_name
 from pyoozie.tags import WorkflowApp
 
 
-__version__ = '0.0.8'
+__version__ = '0.0.9'
 
 __all__ = (
 


### PR DESCRIPTION
One very minor change in this release:
- Gate `typing` module to python versions < 3.5 (#86)